### PR TITLE
スタート機能作成

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -16,7 +16,7 @@ class ApplicationController < ActionController::Base
   end
 
   def check_course_params
-    redirect_to new_history_path_path, flash: {error: '片道か往復から選択してください'} if !Settings.course_type.include?(params[:course])
+    redirect_to new_history_path, flash: {error: '片道か往復から選択してください'} if !Settings.course_type.include?(params[:course])
   end
 
   def check_departure_session_and_set_departure_info

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -15,6 +15,10 @@ class ApplicationController < ActionController::Base
     redirect_to new_search_destination_path, flash: {error: '目的地の検索が実行されていません'} if !session[:results]
   end
 
+  def check_course_params
+    redirect_to new_history_path_path, flash: {error: '片道か往復から選択してください'} if !Settings.course_type.include?(params[:course])
+  end
+
   def check_departure_session_and_set_departure_info
     check_departure_session
     @departure_info = session[:departure]

--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -1,4 +1,8 @@
 class HistoriesController < ApplicationController
+  before_action :check_departure_session, only: %i[create]
+  before_action :check_destination_session, only: %i[create]
+  before_action :check_course_params, only: %i[create]
+
   def new
     destination = current_user.destinations.find_by(uuid: params[:destination])
     session[:destination] = destination.attributes_for_session if destination
@@ -10,5 +14,15 @@ class HistoriesController < ApplicationController
     check_departure_session_and_set_departure_info
 
     gon.locationInfo = {departure: @departure_info, destination: @destination_info}
+  end
+
+  def create
+    history = CreateHistoryService.new(current_user, session[:departure], session[:destination], params[:course]).call
+    redirect_to new_history_path if !history
+    redirect_to history_path(history.uuid)
+  end
+
+  def show
+    @history = current_user.histories.find_by(uuid: params[:id])
   end
 end

--- a/app/controllers/search/departures_controller.rb
+++ b/app/controllers/search/departures_controller.rb
@@ -27,6 +27,6 @@ class Search::DeparturesController < ApplicationController
 
   def set_saved_departures_and_histories
     @departures = current_user.departures.saved_list
-    @histories = current_user.histories.list
+    @histories = current_user.histories.finished_list
   end
 end

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -3,10 +3,10 @@ class History < ApplicationRecord
   belongs_to :destination
   has_one :departure, through: :destination
 
-  validates :start_time, presence: true
   validates :moving_distance, presence: true, numericality: {only_integer: true, greater_than_or_equal_to: 1, less_than_or_equal_to: 42195}
 
   before_create -> { self.uuid = SecureRandom.uuid }
+  before_create -> { self.start_time = DateTime.now }
 
   scope :with_location, -> { includes(destination: [departure: :location], destination: :location) }
   scope :recent, -> { order(created_at: :desc) }

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -9,7 +9,9 @@ class History < ApplicationRecord
   before_create -> { self.start_time = DateTime.now }
 
   scope :with_location, -> { includes(destination: [departure: :location], destination: :location) }
+  scope :finished, -> { where.not(end_time: nil) }
   scope :recent, -> { order(created_at: :desc) }
 
   scope :list, -> { with_location.recent }
+  scope :finished_list, -> { finished.with_location.recent }
 end

--- a/app/services/create_history_service.rb
+++ b/app/services/create_history_service.rb
@@ -1,0 +1,32 @@
+class CreateHistoryService
+  def initialize(user, departure_info, destination_info, course_type)
+    @user, @departure_info, @destination_info, @course_type = user, departure_info, destination_info, course_type
+  end
+
+  def call
+    if destination_info[:uuid]
+      destination = user.destinations.find_by!(uuid: destination_info[:uuid])
+      departure = destination.departure
+    elsif departure_info[:uuid]
+      departure = user.departures.find_by!(uuid: departure_info[:uuid])
+      location = Location.create!(destination_info.select { |k, v| k != :distance })
+      destination = user.destinations.create!(location: location, departure: departure, distance: destination_info[:distance])
+    else
+      departure_location = Location.create!(departure_info)
+      departure = user.departures.create!(location: departure_location)
+      destination_location = Location.create!(destination_info.select { |k, v| k != :distance })
+      destination = user.destinations.create!(location: destination_location, departure: departure, distance: destination_info[:distance])
+    end
+
+    case course_type
+    when 'one_way'
+      user.histories.create!(destination: destination, moving_distance: destination.distance)
+    when 'round_trip'
+      user.histories.create!(destination: destination, moving_distance: (destination.distance * 2))
+    end
+  end
+
+  private
+
+  attr_reader :user, :departure_info, :destination_info, :course_type
+end

--- a/app/views/histories/_start_button.html.erb
+++ b/app/views/histories/_start_button.html.erb
@@ -1,9 +1,9 @@
 <div class="text-center my-5">
-  <%= link_to 'スタート(片道)', '#',
+  <%= link_to 'スタート(片道)', histories_path(course: 'one_way'),
   data: { turbo_method: :post },
   class: 'orange-btn tracking-widest text-xl px-12 py-3 sm:mr-12 zen-kaku-medium mb-5 sm:mb-0 block sm:inline-block' %>
 
-  <%= link_to 'スタート(往復)', '#',
+  <%= link_to 'スタート(往復)', histories_path(course: 'round_trip'),
   data: { turbo_method: :post },
   class: 'orange-btn tracking-widest text-xl px-12 py-3 zen-kaku-medium block sm:inline-block' %>
 </div>

--- a/app/views/histories/new.html.erb
+++ b/app/views/histories/new.html.erb
@@ -6,7 +6,7 @@
   <%= render 'destination', departure_info: @departure_info, destination_info: @destination_info %>
 
   <%= turbo_frame_tag 'start-button-field' do %>
-    <%= render 'form' %>
+    <%= render 'start_button' %>
   <% end %>
 <% end %>
 

--- a/app/views/histories/show.html.erb
+++ b/app/views/histories/show.html.erb
@@ -1,0 +1,3 @@
+<%= turbo_frame_tag 'start-button-field' do %>
+  <%= @history.attributes %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,5 +17,5 @@ Rails.application.routes.draw do
   end
 
   resources :destinations, only: %i[new create]
-  resources :histories, only: %i[new]
+  resources :histories, only: %i[new create show]
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -21,4 +21,8 @@ google:
       '店舗': 'store',
       'スーパーマーケット': 'supermarket',
       '観光スポット': 'tourist_attraction',
-      }
+  }
+course_type: [
+  'one_way',
+  'round_trip'
+]

--- a/db/migrate/20220904033138_create_histories.rb
+++ b/db/migrate/20220904033138_create_histories.rb
@@ -4,7 +4,7 @@ class CreateHistories < ActiveRecord::Migration[7.0]
       t.references :user, null: false, foreign_key: true
       t.references :destination, null: false, foreign_key: true
       t.datetime :start_time, null: false
-      t.datetime :end_time, null: false
+      t.datetime :end_time
       t.integer :moving_distance, null: false
       t.string :uuid, null: false
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,7 +45,7 @@ ActiveRecord::Schema[7.0].define(version: 2022_09_04_033138) do
     t.bigint "user_id", null: false
     t.bigint "destination_id", null: false
     t.datetime "start_time", null: false
-    t.datetime "end_time", null: false
+    t.datetime "end_time"
     t.integer "moving_distance", null: false
     t.string "uuid", null: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
- 出発地目的地を保存済み未保存に合わせて作成しながら履歴作成する機能を作成
└ #31 
- 片道往復選べる機能を作成
└ #31 
- start_timeは自動で入力
└ #31 
- ガード節追加
- 片道往復は定数で管理
- end_timeにnull: falseがついていた部分を修正
- 出発地選択の際、終了済みの履歴のみが表示されるように変更