### PR TITLE
修正箇所をまとめて

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,12 +11,12 @@ AllCops:
 
 # メソッドの代入、メソッド呼び出し、条件分岐のサイズが設定された最大値を超えていないことを確認します。
 Metrics/AbcSize:
-  Max: 22
+  Max: 23.28
 
 # メソッドの長さが最大値を超えるかどうか
 Metrics/MethodLength:
   CountComments: false
-  Max: 12
+  Max: 14
 
 # has_, is_, have_ など、特定の文字列で始まるメソッド名をチェック
 Naming/PredicateName:

--- a/app/controllers/departures_controller.rb
+++ b/app/controllers/departures_controller.rb
@@ -42,6 +42,7 @@ class DeparturesController < ApplicationController
     else
       result = Api::GeocodeService.new(departure_form).call
       return render_edit_departure('位置情報の取得に失敗しました') unless result
+
       @location.update!(result.compact)
     end
 
@@ -75,7 +76,7 @@ class DeparturesController < ApplicationController
   def render_edit_departure(error_message)
     # @locationが作成されていることや、location_paramsを受け取っていることに依存しているため注意
     @location.attributes = location_params
-    flash.now[:error] = '入力情報に誤りがあります'
+    flash.now[:error] = error_message
     render :edit, status: :unprocessable_entity
   end
 

--- a/app/controllers/departures_controller.rb
+++ b/app/controllers/departures_controller.rb
@@ -17,7 +17,7 @@ class DeparturesController < ApplicationController
 
   def create
     @departure_form = DepartureForm.new(departure_form_params)
-    return render_new_departure('入力情報に誤りがあります') unless @departure_form.valid?
+    return render_new_departure('入力情報に誤りがあります') unless @departure_form.valid?(:check_is_saved)
 
     result = Api::GeocodeService.new(@departure_form).call
     return render_new_departure('位置情報の取得に失敗しました') unless result
@@ -34,12 +34,18 @@ class DeparturesController < ApplicationController
   end
 
   def update
-    if @location.update(location_params)
-      redirect_to departure_path(@departure.uuid), flash: { success: '出発地を更新しました' }
+    departure_form = DepartureForm.new(location_params)
+    return render_edit_departure('入力情報に誤りがあります') unless departure_form.valid?
+
+    if @location.address == departure_form.address
+      @location.update!(location_params)
     else
-      flash.now[:error] = '入力情報に誤りがあります'
-      render :edit, status: :unprocessable_entity
+      result = Api::GeocodeService.new(departure_form).call
+      return render_edit_departure('位置情報の取得に失敗しました') unless result
+      @location.update!(result.compact)
     end
+
+    redirect_to departure_path(@departure.uuid), flash: { success: '出発地を更新しました' }
   end
 
   def destroy
@@ -64,6 +70,13 @@ class DeparturesController < ApplicationController
     set_saved_departures_and_histories
     flash.now[:error] = error_message
     render :new, status: :unprocessable_entity
+  end
+
+  def render_edit_departure(error_message)
+    # @locationが作成されていることや、location_paramsを受け取っていることに依存しているため注意
+    @location.attributes = location_params
+    flash.now[:error] = '入力情報に誤りがあります'
+    render :edit, status: :unprocessable_entity
   end
 
   def departure_form_params

--- a/app/controllers/destinations_controller.rb
+++ b/app/controllers/destinations_controller.rb
@@ -86,6 +86,6 @@ class DestinationsController < ApplicationController
 
   def location_and_destination_params
     destination_attributes = %i[comment is_published_comment distance id]
-    params.require(:location).permit(:name, :address, destination_attributes:)
+    params.require(:location).permit(:name, destination_attributes:)
   end
 end

--- a/app/controllers/destinations_controller.rb
+++ b/app/controllers/destinations_controller.rb
@@ -19,13 +19,15 @@ class DestinationsController < ApplicationController
     gon.locationInfo = { departure: session[:departure], destination: @candidate }
   end
 
-  def edit; end
+  def edit
+    @destination_form = DestinationForm.new(@destination.attributes_for_form)
+  end
 
   # turbo_frameリクエスト
   def create
     @destination_form = DestinationForm.new(destination_form_params)
 
-    unless @destination_form.valid?
+    unless @destination_form.valid?(:check_is_saved)
       flash.now[:error] = '入力情報に誤りがあります'
       return render :new, status: :unprocessable_entity
     end
@@ -43,16 +45,18 @@ class DestinationsController < ApplicationController
   end
 
   def update
-    if @location.update(location_and_destination_params)
-      case @route
-      when 'start_page'
-        redirect_to new_history_path(destination: @destination.uuid), flash: { success: ' 目的地を更新しました' }
-      when 'saved_page'
-        redirect_to destination_path(@destination.uuid), flash: { success: ' 目的地を更新しました' }
-      end
-    else
+    @destination_form = DestinationForm.new(edit_destination_form_params)
+    unless @destination_form.valid?
       flash.now[:error] = '入力情報に誤りがあります'
-      render :edit, status: :unprocessable_entity
+      return render :edit, status: :unprocessable_entity
+    end
+
+    @destination.update_with_location(@destination_form)
+    case @route
+    when 'start_page'
+      redirect_to new_history_path(destination: @destination.uuid), flash: { success: ' 目的地を更新しました' }
+    when 'saved_page'
+      redirect_to destination_path(@destination.uuid), flash: { success: ' 目的地を更新しました' }
     end
   end
 
@@ -84,8 +88,7 @@ class DestinationsController < ApplicationController
     params.require(:destination_form).permit(:name, :comment, :is_published_comment, :distance, :is_saved)
   end
 
-  def location_and_destination_params
-    destination_attributes = %i[comment is_published_comment distance id]
-    params.require(:location).permit(:name, destination_attributes:)
+  def edit_destination_form_params
+    params.require(:destination_form).permit(:name, :comment, :is_published_comment, :distance)
   end
 end

--- a/app/forms/departure_form.rb
+++ b/app/forms/departure_form.rb
@@ -8,7 +8,7 @@ class DepartureForm
 
   validates :name, presence: true, length: { maximum: 50 }
   validates :address, presence: true, length: { maximum: 255 }
-  validates :is_saved, inclusion: { in: [true, false] }
+  validates :is_saved, inclusion: { in: [true, false] }, on: :check_is_saved
   validate :address_format_check
 
   private

--- a/app/forms/departure_form.rb
+++ b/app/forms/departure_form.rb
@@ -9,4 +9,12 @@ class DepartureForm
   validates :name, presence: true, length: { maximum: 50 }
   validates :address, presence: true, length: { maximum: 255 }
   validates :is_saved, inclusion: { in: [true, false] }
+  validate :address_format_check
+
+  private
+
+  def address_format_check
+    return unless address.present?
+    errors.add(:address, 'は〇丁目〇〇や、〇-〇〇といった形で正確に記入してください') unless address.match(/.+[\d１-９]{1,4}[-ー丁−]{1}.{0,2}[\d０-９].*/)
+  end
 end

--- a/app/forms/departure_form.rb
+++ b/app/forms/departure_form.rb
@@ -9,13 +9,4 @@ class DepartureForm
   validates :name, presence: true, length: { maximum: 50 }
   validates :address, presence: true, length: { maximum: 255 }
   validates :is_saved, inclusion: { in: [true, false] }, on: :check_is_saved
-  validate :address_format_check
-
-  private
-
-  def address_format_check
-    return if address.blank?
-
-    errors.add(:address, 'は〇丁目〇〇や、〇-〇〇といった形で正確に記入してください') unless address.match(/.+[\d１-９]{1,4}[-ー丁−]{1}.{0,2}[\d０-９].*/)
-  end
 end

--- a/app/forms/departure_form.rb
+++ b/app/forms/departure_form.rb
@@ -14,7 +14,8 @@ class DepartureForm
   private
 
   def address_format_check
-    return unless address.present?
+    return if address.blank?
+
     errors.add(:address, 'は〇丁目〇〇や、〇-〇〇といった形で正確に記入してください') unless address.match(/.+[\d１-９]{1,4}[-ー丁−]{1}.{0,2}[\d０-９].*/)
   end
 end

--- a/app/forms/destination_form.rb
+++ b/app/forms/destination_form.rb
@@ -11,7 +11,7 @@ class DestinationForm
   validates :name, presence: true, length: { maximum: 50 }
   validates :comment, length: { maximum: 255 }
   validates :distance, presence: true, numericality: { only_integer: true, in: 1..21_097 }
-  validates :is_saved, inclusion: { in: [true, false] }
+  validates :is_saved, inclusion: { in: [true, false] }, on: :check_is_saved
   validates :is_published_comment, inclusion: { in: [true, false] }
 
   def attributes_for_session(candidate)

--- a/app/models/destination.rb
+++ b/app/models/destination.rb
@@ -39,10 +39,21 @@ class Destination < ApplicationRecord
     create!(attributes_for_create)
   end
 
+  def update_with_location(destination_form)
+    location.update!(name: destination_form.name)
+    destination_params = destination_form.attributes.except('name').compact
+    update!(destination_params)
+  end
+
   # destination_info
   def attributes_for_session
     attributes_hash = variable_in_attributes.merge(fixed_in_attributes)
     attributes_hash.merge(uuid:, distance:, comment:, is_published_comment:, created_at:)
+  end
+
+  # destination_form
+  def attributes_for_form
+    { name: location.name, comment:, is_published_comment:, distance: }
   end
 
   # candidate

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -9,9 +9,17 @@ class Location < ApplicationRecord
   validates :longitude, presence: true, numericality: { in: -180..180 }
   validates :address, presence: true, length: { maximum: 255 }
   validates :place_id, presence: true, length: { maximum: 255 }
+  validate :address_format_check
 
   def self.create_from_info(location_info)
     attribute_symboles = location_info.slice(:name, :latitude, :longitude, :address, :place_id)
     create!(attribute_symboles)
+  end
+
+  private
+
+  def address_format_check
+    return unless address.present?
+    errors.add(:address, 'は〇丁目〇〇や、〇-〇〇といった形で正確に記入してください') unless address.match(/.+[\d１-９]{1,4}[-ー丁−]{1}.{0,2}[\d０-９].*/)
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -19,7 +19,8 @@ class Location < ApplicationRecord
   private
 
   def address_format_check
-    return unless address.present?
+    return if address.blank?
+
     errors.add(:address, 'は〇丁目〇〇や、〇-〇〇といった形で正確に記入してください') unless address.match(/.+[\d１-９]{1,4}[-ー丁−]{1}.{0,2}[\d０-９].*/)
   end
 end

--- a/app/models/location.rb
+++ b/app/models/location.rb
@@ -9,18 +9,9 @@ class Location < ApplicationRecord
   validates :longitude, presence: true, numericality: { in: -180..180 }
   validates :address, presence: true, length: { maximum: 255 }
   validates :place_id, presence: true, length: { maximum: 255 }
-  validate :address_format_check
 
   def self.create_from_info(location_info)
     attribute_symboles = location_info.slice(:name, :latitude, :longitude, :address, :place_id)
     create!(attribute_symboles)
-  end
-
-  private
-
-  def address_format_check
-    return if address.blank?
-
-    errors.add(:address, 'は〇丁目〇〇や、〇-〇〇といった形で正確に記入してください') unless address.match(/.+[\d１-９]{1,4}[-ー丁−]{1}.{0,2}[\d０-９].*/)
   end
 end

--- a/app/services/api/geocode_service.rb
+++ b/app/services/api/geocode_service.rb
@@ -27,7 +27,7 @@ module Api
 
     def parse_address(result)
       address = pick_address(result).match(/.*[\d１-９]{3}[-ー−][\d１-９]{4}\s*(.+)/)
-      return false unless address[1].match(/.+[\d１-９]{1,4}[-ー丁−]{1}.{0,2}[\d０-９].*/)
+      return false unless address
 
       address[1].tr('０-９ａ-ｚＡ-Ｚ．＠ー−-', '0-9a-zA-Z.@-')
     end

--- a/app/services/api/geocode_service.rb
+++ b/app/services/api/geocode_service.rb
@@ -28,7 +28,8 @@ module Api
     def parse_address(result)
       address = pick_address(result).match(/.*[\d１-９]{3}[-ー−][\d１-９]{4}\s*(.+)/)
       return false unless address[1].match(/.+[\d１-９]{1,4}[-ー丁−]{1}.{0,2}[\d０-９].*/)
-      address[1].tr("０-９ａ-ｚＡ-Ｚ．＠ー−-", "0-9a-zA-Z.@-")
+
+      address[1].tr('０-９ａ-ｚＡ-Ｚ．＠ー−-', '0-9a-zA-Z.@-')
     end
 
     def check_result(result)

--- a/app/services/api/geocode_service.rb
+++ b/app/services/api/geocode_service.rb
@@ -26,8 +26,9 @@ module Api
     end
 
     def parse_address(result)
-      address = pick_address(result).match(/.*[\d１-９]{3}[-ー−][\d１-９]{4}\s*(.+)/)[1]
-      address.tr("０-９ａ-ｚＡ-Ｚ．＠ー−-", "0-9a-zA-Z.@-")
+      address = pick_address(result).match(/.*[\d１-９]{3}[-ー−][\d１-９]{4}\s*(.+)/)
+      return false unless address[1].match(/.+[\d１-９]{1,4}[-ー丁−]{1}.{0,2}[\d０-９].*/)
+      address[1].tr("０-９ａ-ｚＡ-Ｚ．＠ー−-", "0-9a-zA-Z.@-")
     end
 
     def check_result(result)

--- a/app/services/api/geocode_service.rb
+++ b/app/services/api/geocode_service.rb
@@ -29,7 +29,7 @@ module Api
       address = pick_address(result).match(/.*[\d１-９]{3}[-ー−][\d１-９]{4}\s*(.+)/)
       return false unless address
 
-      address[1].tr('０-９ａ-ｚＡ-Ｚ．＠ー−-', '0-9a-zA-Z.@-')
+      address[1].tr('０-９ａ-ｚＡ-Ｚ．＠−', '0-9a-zA-Z.@-').gsub(/\d(ー)/, '-')
     end
 
     def check_result(result)

--- a/app/services/api/geocode_service.rb
+++ b/app/services/api/geocode_service.rb
@@ -26,8 +26,8 @@ module Api
     end
 
     def parse_address(result)
-      address = pick_address(result).match(/.*[\d１-９]{3}[-ー][\d１-９]{4}\s*(.+)/)[1]
-      address.tr("０-９ａ-ｚＡ-Ｚ．＠−", "0-9a-zA-Z.@-")
+      address = pick_address(result).match(/.*[\d１-９]{3}[-ー−][\d１-９]{4}\s*(.+)/)[1]
+      address.tr("０-９ａ-ｚＡ-Ｚ．＠ー−-", "0-9a-zA-Z.@-")
     end
 
     def check_result(result)

--- a/app/services/api/nearby_service.rb
+++ b/app/services/api/nearby_service.rb
@@ -9,7 +9,8 @@ module Api
 
     def call
       results = calculation
-      results ? parse_results(results) : false
+      results = address_format_check(results).compact
+      results.present? ? parse_results(results) : false
     end
 
     private
@@ -34,11 +35,18 @@ module Api
       send_request(url)
     end
 
+    def address_format_check(results)
+      results.map do |result|
+        next unless result[:vicinity].match(/.+[\d１-９]{1,4}[-ー丁−]{1}.{0,2}[\d０-９].*/)
+        result
+      end
+    end
+
     def parse_results(results)
       results.map do |result|
         latitude = result[:geometry][:location][:lat]
         longitude = result[:geometry][:location][:lng]
-        address = result[:vicinity]
+        address = result[:vicinity].tr("０-９ａ-ｚＡ-Ｚ．＠ー−-", "0-9a-zA-Z.@-")
         place_id = result[:place_id]
 
         variable = { uuid: SecureRandom.uuid, name: result[:name] }

--- a/app/services/api/nearby_service.rb
+++ b/app/services/api/nearby_service.rb
@@ -9,8 +9,7 @@ module Api
 
     def call
       results = calculation
-      results = address_format_check(results).compact
-      results.present? ? parse_results(results) : false
+      results ? parse_results(results) : false
     end
 
     private
@@ -33,14 +32,6 @@ module Api
       encode_parameters = { location: parse_location, radius:, type: search_term_form.type }.to_query
       url = Settings.google.nearby_url + encode_parameters
       send_request(url)
-    end
-
-    def address_format_check(results)
-      results.map do |result|
-        next unless result[:vicinity].match(/.+[\d１-９]{1,4}[-ー丁−]{1}.{0,2}[\d０-９].*/)
-
-        result
-      end
     end
 
     def parse_results(results)

--- a/app/services/api/nearby_service.rb
+++ b/app/services/api/nearby_service.rb
@@ -38,7 +38,7 @@ module Api
       results.map do |result|
         latitude = result[:geometry][:location][:lat]
         longitude = result[:geometry][:location][:lng]
-        address = result[:vicinity].tr('０-９ａ-ｚＡ-Ｚ．＠ー−-', '0-9a-zA-Z.@-')
+        address = result[:vicinity].tr('０-９ａ-ｚＡ-Ｚ．＠−', '0-9a-zA-Z.@-').gsub(/\d(ー)/, '-')
         place_id = result[:place_id]
 
         variable = { uuid: SecureRandom.uuid, name: result[:name] }

--- a/app/services/api/nearby_service.rb
+++ b/app/services/api/nearby_service.rb
@@ -38,6 +38,7 @@ module Api
     def address_format_check(results)
       results.map do |result|
         next unless result[:vicinity].match(/.+[\d１-９]{1,4}[-ー丁−]{1}.{0,2}[\d０-９].*/)
+
         result
       end
     end
@@ -46,7 +47,7 @@ module Api
       results.map do |result|
         latitude = result[:geometry][:location][:lat]
         longitude = result[:geometry][:location][:lng]
-        address = result[:vicinity].tr("０-９ａ-ｚＡ-Ｚ．＠ー−-", "0-9a-zA-Z.@-")
+        address = result[:vicinity].tr('０-９ａ-ｚＡ-Ｚ．＠ー−-', '0-9a-zA-Z.@-')
         place_id = result[:place_id]
 
         variable = { uuid: SecureRandom.uuid, name: result[:name] }

--- a/app/views/destinations/edit.html.erb
+++ b/app/views/destinations/edit.html.erb
@@ -10,12 +10,6 @@
           <%= render partial: 'shared/error_message', collection: @location.errors.full_messages_for(:name) %>
         </div>
 
-        <div class="my-5">
-          <%= f.label :address %>
-          <%= f.text_field :address, class: 'normal-form', id: 'js-address-form' %>
-          <%= render partial: 'shared/error_message', collection: @location.errors.full_messages_for(:address) %>
-        </div>
-
         <%= f.fields_for :destination do |destination| %>
           <div class="my-5">
             <%= destination.label :comment %>

--- a/app/views/destinations/edit.html.erb
+++ b/app/views/destinations/edit.html.erb
@@ -3,32 +3,30 @@
     <div class="info-card pb-0">
       <%= render 'shared/toast' if is_turbo_frame_request? %> <%# destination#updateのバリデーションエラー用 %>
 
-      <%= form_with model: @location, url: destination_path(route: @route), class: 'zen-kaku-medium text-left' do |f| %>
+      <%= form_with model: @destination_form, url: destination_path(@destination.uuid, route: @route), class: 'zen-kaku-medium text-left', method: :patch do |f| %>
         <div class="my-5">
           <%= f.label :name %>
           <%= f.text_field :name, class: 'normal-form' %>
-          <%= render partial: 'shared/error_message', collection: @location.errors.full_messages_for(:name) %>
+          <%= render partial: 'shared/error_message', collection: @destination_form.errors.full_messages_for(:name) %>
         </div>
 
-        <%= f.fields_for :destination do |destination| %>
-          <div class="my-5">
-            <%= destination.label :comment %>
-            <%= destination.text_area :comment, class: 'normal-form h-32', placeholder: '空白でも可' %>
-            <%= render partial: 'shared/error_message', collection: @destination.errors.full_messages_for(:comment) %>
-          </div>
+        <div class="my-5">
+          <%= f.label :comment %>
+          <%= f.text_area :comment, class: 'normal-form h-32', placeholder: '空白でも可' %>
+          <%= render partial: 'shared/error_message', collection: @destination_form.errors.full_messages_for(:comment) %>
+        </div>
 
-          <div class="my-5">
-            <%= destination.check_box :is_published_comment, class: "p-2 mb-1 mr-3 inline-block shadow rounded-lg border border-gray-300 bg-gray-50" %>
-            <%= destination.label :is_published_comment %>
-            <%= render partial: 'shared/error_message', collection: @destination.errors.full_messages_for(:is_published_comment) %>
-          </div>
+        <div class="my-5">
+          <%= f.check_box :is_published_comment, class: "p-2 mb-1 mr-3 inline-block shadow rounded-lg border border-gray-300 bg-gray-50" %>
+          <%= f.label :is_published_comment %>
+          <%= render partial: 'shared/error_message', collection: @destination_form.errors.full_messages_for(:is_published_comment) %>
+        </div>
 
-          <div class="my-5">
-            <%= destination.label :distance %>
-            <%= destination.number_field :distance, class: 'normal-form' %>
-            <%= render partial: 'shared/error_message', collection: @destination.errors.full_messages_for(:distance) %>
-          </div>
-        <% end %>
+        <div class="my-5">
+          <%= f.label :distance %>
+          <%= f.number_field :distance, class: 'normal-form' %>
+          <%= render partial: 'shared/error_message', collection: @destination_form.errors.full_messages_for(:distance) %>
+        </div>
 
         <div class="my-5 text-right zen-kaku-regular text-xl tracking-wider">
           <%= link_to '取消', destination_path(@destination.uuid, route: @route), class: 'border-orange-btn px-5 py-2' %>

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -14,7 +14,7 @@ coordinates:
   third_request_success: [{ latitude: 90, longitude: 180, latitude: -90, longitude: 180, latitude:  35.66622427379104, longitude: 139.75129174985798 } ]
   no_result: [{ latitude: 90, longitude: 180, latitude: -90, longitude: 180, latitude: -90, longitude: 0 } ]
 nearby_result:
-  radius_1000: { variable: { uuid: '1263ab59-0996-4bc3-b6fc-fc4e035a2004', name: 'ファミリーマート 新橋仲通り南店' }, fixed: { latitude: 35.666915, longitude: 139.7557323, address: '港区新橋２丁目１０−５', place_id: 'ChIJQ3_ul-uLGGARZPKSaHYKooA' } }
-  radius_5000: { variable: { uuid: '1263ab59-0996-4bc3-b6fc-fc4e035a2004', name: 'ローソン ゲートシティ大崎店' }, fixed: { latitude: 35.6189257, longitude: 139.7316987, address: '品川区大崎１丁目１１−２ イースト１Ｆ ゲートシティ大崎', place_id: 'ChIJP5DPcPWKGGAR81CoK5yKGGo' } }
-  second_request_success: { variable: { uuid: '1263ab59-0996-4bc3-b6fc-fc4e035a2004', name: 'ファミリーマート 新橋仲通り南店' }, fixed: { latitude: 35.666915, longitude: 139.7557323, address: '港区新橋２丁目１０−５', place_id: 'ChIJQ3_ul-uLGGARZPKSaHYKooA' } }
-  third_request_success: { variable: { uuid: '1263ab59-0996-4bc3-b6fc-fc4e035a2004', name: 'ファミリーマート 新橋仲通り南店' }, fixed: { latitude: 35.666915, longitude: 139.7557323, address: '港区新橋２丁目１０−５', place_id: 'ChIJQ3_ul-uLGGARZPKSaHYKooA' } }
+  radius_1000: { variable: { uuid: '1263ab59-0996-4bc3-b6fc-fc4e035a2004', name: 'ファミリーマート 新橋仲通り南店' }, fixed: { latitude: 35.666915, longitude: 139.7557323, address: '港区新橋2丁目10-5', place_id: 'ChIJQ3_ul-uLGGARZPKSaHYKooA' } }
+  radius_5000: { variable: { uuid: '1263ab59-0996-4bc3-b6fc-fc4e035a2004', name: 'ローソン ゲートシティ大崎店' }, fixed: { latitude: 35.6189257, longitude: 139.7316987, address: '品川区大崎1丁目11-2 イースト1F ゲートシティ大崎', place_id: 'ChIJP5DPcPWKGGAR81CoK5yKGGo' } }
+  second_request_success: { variable: { uuid: '1263ab59-0996-4bc3-b6fc-fc4e035a2004', name: 'ファミリーマート 新橋仲通り南店' }, fixed: { latitude: 35.666915, longitude: 139.7557323, address: '港区新橋2丁目10-5', place_id: 'ChIJQ3_ul-uLGGARZPKSaHYKooA' } }
+  third_request_success: { variable: { uuid: '1263ab59-0996-4bc3-b6fc-fc4e035a2004', name: 'ファミリーマート 新橋仲通り南店' }, fixed: { latitude: 35.666915, longitude: 139.7557323, address: '港区新橋2丁目10-5', place_id: 'ChIJQ3_ul-uLGGARZPKSaHYKooA' } }

--- a/spec/forms/departure_form_spec.rb
+++ b/spec/forms/departure_form_spec.rb
@@ -63,6 +63,7 @@ RSpec.describe DepartureForm, type: :model do
     context '#is_saved' do
       it 'nilを渡す' do
         departure_form = build(:departure_form, is_saved: nil)
+        expect(departure_form.is_saved).to be_nil
         expect(departure_form.valid?(:check_is_saved)).to be_falsey
         expect(departure_form.errors[:is_saved]).to eq ['は一覧にありません']
       end

--- a/spec/forms/departure_form_spec.rb
+++ b/spec/forms/departure_form_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe DepartureForm, type: :model do
   describe 'Validations' do
     it '全てのカラムを入力する' do
       departure_form = build(:departure_form)
-      expect(departure_form).to be_valid
+      expect(departure_form.valid?(:check_is_saved)).to be_truthy
       expect(departure_form.errors).to be_empty
     end
 
@@ -63,35 +63,35 @@ RSpec.describe DepartureForm, type: :model do
     context '#is_saved' do
       it 'nilを渡す' do
         departure_form = build(:departure_form, is_saved: nil)
-        expect(departure_form).to be_invalid
+        expect(departure_form.valid?(:check_is_saved)).to be_falsey
         expect(departure_form.errors[:is_saved]).to eq ['は一覧にありません']
       end
 
       it '空の文字列を入力する' do
         departure_form = build(:departure_form, is_saved: '')
         expect(departure_form.is_saved).to be_nil
-        expect(departure_form).to be_invalid
+        expect(departure_form.valid?(:check_is_saved)).to be_falsey
         expect(departure_form.errors[:is_saved]).to eq ['は一覧にありません']
       end
 
       it '空ではない文字列を入力する' do
         departure_form = build(:departure_form, is_saved: ' ')
         expect(departure_form.is_saved).to be_truthy
-        expect(departure_form).to be_valid
+        expect(departure_form.valid?(:check_is_saved)).to be_truthy
         expect(departure_form.errors).to be_empty
       end
 
       it '0を入力する' do
         departure_form = build(:departure_form, is_saved: 0)
         expect(departure_form.is_saved).to be_falsey
-        expect(departure_form).to be_valid
+        expect(departure_form.valid?(:check_is_saved)).to be_truthy
         expect(departure_form.errors).to be_empty
       end
 
       it '1を入力する' do
         departure_form = build(:departure_form, is_saved: 1)
         expect(departure_form.is_saved).to be_truthy
-        expect(departure_form).to be_valid
+        expect(departure_form.valid?(:check_is_saved)).to be_truthy
         expect(departure_form.errors).to be_empty
       end
     end

--- a/spec/forms/destination_form_spec.rb
+++ b/spec/forms/destination_form_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe DestinationForm, type: :model do
   describe 'Validations' do
     it '全てのカラムを入力する' do
       destination_form = build(:destination_form)
-      expect(destination_form).to be_valid
+      expect(destination_form.valid?(:check_is_saved)).to be_truthy
       expect(destination_form.errors).to be_empty
     end
 
@@ -101,35 +101,36 @@ RSpec.describe DestinationForm, type: :model do
     context '#is_saved' do
       it 'nilを渡す' do
         destination_form = build(:destination_form, is_saved: nil)
-        expect(destination_form).to be_invalid
+        expect(destination_form.is_saved).to be_nil
+        expect(destination_form.valid?(:check_is_saved)).to be_falsey
         expect(destination_form.errors[:is_saved]).to eq ['は一覧にありません']
       end
 
       it '空の文字列を入力する' do
         destination_form = build(:destination_form, is_saved: '')
         expect(destination_form.is_saved).to be_nil
-        expect(destination_form).to be_invalid
+        expect(destination_form.valid?(:check_is_saved)).to be_falsey
         expect(destination_form.errors[:is_saved]).to eq ['は一覧にありません']
       end
 
       it '空ではない文字列を入力する' do
         destination_form = build(:destination_form, is_saved: ' ')
         expect(destination_form.is_saved).to be_truthy
-        expect(destination_form).to be_valid
+        expect(destination_form.valid?(:check_is_saved)).to be_truthy
         expect(destination_form.errors).to be_empty
       end
 
       it '0を入力する' do
         destination_form = build(:destination_form, is_saved: 0)
         expect(destination_form.is_saved).to be_falsey
-        expect(destination_form).to be_valid
+        expect(destination_form.valid?(:check_is_saved)).to be_truthy
         expect(destination_form.errors).to be_empty
       end
 
       it '1を入力する' do
         destination_form = build(:destination_form, is_saved: 1)
         expect(destination_form.is_saved).to be_truthy
-        expect(destination_form).to be_valid
+        expect(destination_form.valid?(:check_is_saved)).to be_truthy
         expect(destination_form.errors).to be_empty
       end
     end
@@ -137,6 +138,7 @@ RSpec.describe DestinationForm, type: :model do
     context '#is_published_comment' do
       it 'nilを渡す' do
         destination_form = build(:destination_form, is_published_comment: nil)
+        expect(destination_form.is_published_comment).to be_nil
         expect(destination_form).to be_invalid
         expect(destination_form.errors[:is_published_comment]).to eq ['は一覧にありません']
       end

--- a/spec/models/departure_spec.rb
+++ b/spec/models/departure_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Departure, type: :model do
     context '#is_saved' do
       it 'nilを渡す' do
         departure = build(:departure, is_saved: nil)
+        expect(departure.is_saved).to be_nil
         expect(departure).to be_invalid
         expect(departure.errors[:is_saved]).to eq ['は一覧にありません']
       end

--- a/spec/models/destination_spec.rb
+++ b/spec/models/destination_spec.rb
@@ -75,6 +75,7 @@ describe 'Validations' do
     context '#is_saved' do
       it 'nilを渡す' do
         destination = build(:destination, is_saved: nil)
+        expect(destination.is_saved).to be_nil
         expect(destination).to be_invalid
         expect(destination.errors[:is_saved]).to eq ['は一覧にありません']
       end


### PR DESCRIPTION
#64
- fields_for削除
- 目的地の住所は変更できないように変更
- 住所のフォーマットチェックをしない
- 出発地の住所変更の際、geocodeにリクエスト
- model specでis_savedで抜けている確認箇所を追加

#66 
- 住所の数字や記号を半角に変えて表示・保存する機能の追加に合わせたテストの修正