### PR TITLE
検索処理の目的地一覧までのSystem Spec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
     - "config/**/*"
     - 'db/**/*'
     - "lib/**/*"
-    - 'spec/**/*'
+    # - 'spec/**/*'
     - 'vendor/**/*'
     - 'app/helpers/page_helper.rb'
 
@@ -44,3 +44,4 @@ Rails/I18nLocaleTexts:
 
 require:
     - rubocop-rails
+    - rubocop-rspec

--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,9 @@ group :development do
 
   # リントチェック拡張
   gem 'rubocop-rails', require: false
+
+  # rspecリントチェック
+  gem 'rubocop-rspec', require: false
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,10 +301,15 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.24.1)
       parser (>= 3.1.1.0)
+    rubocop-capybara (2.17.1)
+      rubocop (~> 1.41)
     rubocop-rails (2.17.4)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.33.0, < 2.0)
+    rubocop-rspec (2.19.0)
+      rubocop (~> 1.33)
+      rubocop-capybara (~> 2.17)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
@@ -391,6 +396,7 @@ DEPENDENCIES
   rspec-rails
   rubocop
   rubocop-rails
+  rubocop-rspec
   sitemap_generator
   sorcery
   sprockets-rails

--- a/app/javascript/map/geocode.js
+++ b/app/javascript/map/geocode.js
@@ -3,7 +3,7 @@ import toastr from "toastr";
 window.getCurrentLocation = () => {
   const button = document.getElementById('js-get-current-location-button');
   const loading = document.getElementById('js-loading-text');
-  const form = document.getElementById('js-address-form')
+  const form = document.getElementById('departure_form_address')
 
   toastr.options = {
     "closeButton": true,

--- a/app/services/pick_candidates_service.rb
+++ b/app/services/pick_candidates_service.rb
@@ -65,7 +65,7 @@ class PickCandidatesService
 
   def remove_duplicates(pick_candidates)
     place_id_arr = []
-    pick_candidates.each do |_k, candidates|
+    pick_candidates.reverse_each do |_k, candidates|
       candidates.delete_if { |candidate| place_id_arr.include?(candidate[:fixed][:place_id]) }
       place_id_arr += candidates.map { |candidate| candidate[:fixed][:place_id] }
     end

--- a/app/views/departures/_form.html.erb
+++ b/app/views/departures/_form.html.erb
@@ -7,7 +7,7 @@
 
   <div class="my-5">
     <%= f.label :address %>
-    <%= f.text_field :address, class: 'normal-form', id: 'js-address-form' %>
+    <%= f.text_field :address, class: 'normal-form' %>
     <%= link_to '現在地取得', '#', class: 'text-blue-600 underline', id: 'js-get-current-location-button' %>
     <p class="hidden" id="js-loading-text">読込中……</p>
     <%= render partial: 'shared/error_message', collection: departure_form.errors.full_messages_for(:address) %>

--- a/app/views/departures/new.html.erb
+++ b/app/views/departures/new.html.erb
@@ -33,4 +33,7 @@
   </div>
 </div>
 
-<%= javascript_include_tag Settings.google.map_url + 'callback=getCurrentLocation', defer: 'defer' %>
+<% # 現在地取得のテストは一旦保留するため、読み込まない %>
+<% unless Rails.env.test? %>
+  <%= javascript_include_tag Settings.google.map_url + 'callback=getCurrentLocation', defer: 'defer' %>
+<% end %>

--- a/app/views/searches/_comment.html.erb
+++ b/app/views/searches/_comment.html.erb
@@ -1,6 +1,6 @@
 <% if comment.instance_of?(Array) %>
   <div class="flex justify-center items-center">
-    <p>
+    <p class="mr-3 sm:mr-4">
       <% if is_published_comment.nil? || is_published_comment %>
         <%= fa_icon 'eye' %>
       <% else %>
@@ -8,11 +8,11 @@
       <% end %>
       <%= fa_icon 'commenting' %>
     </p>
-    <div>
+    <div class="text-left ml-3 sm:ml-4">
       <% comment.each do |c| %>
-        <p>
-          <%= "・#{c}" %>
-        </p>
+        <ul class="list-disc">
+          <li><%= c %></li>
+        </ul>
       <% end %>
     </div>
   </div>
@@ -23,6 +23,7 @@
     <% else %>
       <%= fa_icon 'eye-slash' %>
     <% end %>
+    <%= fa_icon 'commenting' %>
     <%= comment %>
   </p>
 <% end %>

--- a/app/views/searches/index.html.erb
+++ b/app/views/searches/index.html.erb
@@ -36,4 +36,8 @@
 </div>
 
 <%= include_gon %>
-<%= javascript_include_tag Settings.google.map_url + 'callback=showCandidates', defer: 'defer' %>
+
+<% # 表示されているMapのテストは一旦保留するため、読み込まない %>
+<% unless Rails.env.test? %>
+  <%= javascript_include_tag Settings.google.map_url + 'callback=showCandidates', defer: 'defer' %>
+<% end %>

--- a/app/views/shared/_toast.html.erb
+++ b/app/views/shared/_toast.html.erb
@@ -1,6 +1,6 @@
 <% if flash? %>
   <% flash.each do |type, messages| %>
-    <% if messages.class == Array %>
+    <% if messages.instance_of?(Array) %>
       <% messages.each do |message| %>
         <div  data-controller="toast"
               data-toast-type-value=<%= type %>

--- a/spec/factories/departures.rb
+++ b/spec/factories/departures.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :departure do
     association :user
-    association :location, :designated
+    association :location, :for_departure
 
     trait :another do
       association :location, :random

--- a/spec/factories/destinations.rb
+++ b/spec/factories/destinations.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :destination do
     distance { 1000 }
     association :user
-    association :location, :designated
+    association :location, :for_destination
     association :departure
 
     trait :published_comment do

--- a/spec/factories/histories.rb
+++ b/spec/factories/histories.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
       moving_distance { rand(2001..10000) }
       start_time { Time.zone.now.ago(3.hour) }
       end_time { Time.zone.now.ago(1.hour) }
+      association :destination, :another
     end
   end
 end

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -2,11 +2,18 @@ FactoryBot.define do
   factory :location do
     sequence(:name, 'location-name-1')
 
-    trait :designated do
+    trait :for_departure do
       latitude { '35.6896067' }
       longitude { '139.7005713' }
       address { '東京都港区芝公園4丁目2-8' }
       place_id { 'ChIJH7qx1tCMGGAR1f2s7PGhMhw' }
+    end
+
+    trait :for_destination do
+      latitude { '35.7104881' }
+      longitude { '139.8125376' }
+      address { '東京都墨田区押上1丁目1-1-2' }
+      place_id { 'ChIJYQh5P9aOGGAROVCG_6T_P3Y' }
     end
 
     trait :random do

--- a/spec/factories/locations.rb
+++ b/spec/factories/locations.rb
@@ -10,10 +10,10 @@ FactoryBot.define do
     end
 
     trait :for_destination do
-      latitude { '35.7104881' }
-      longitude { '139.8125376' }
-      address { '東京都墨田区押上1丁目1-1-2' }
-      place_id { 'ChIJYQh5P9aOGGAROVCG_6T_P3Y' }
+      latitude { '35.675888' }
+      longitude { '139.744858' }
+      address { '東京都千代田区永田町1丁目7-1' }
+      place_id { 'ChIJibDhsomLGGARkIZSXvrUx0g' }
     end
 
     trait :random do

--- a/spec/models/location_spec.rb
+++ b/spec/models/location_spec.rb
@@ -3,32 +3,32 @@ require 'rails_helper'
 RSpec.describe Location, type: :model do
   describe 'Validations' do
     it '全てのカラムを入力する' do
-      location = build(:location, :designated)
+      location = build(:location, :for_departure)
       expect(location).to be_valid
       expect(location.errors).to be_empty
     end
 
     context '#name' do
       it 'nilを渡す' do
-        location = build(:location, :designated, name: nil)
+        location = build(:location, :for_departure, name: nil)
         expect(location).to be_invalid
         expect(location.errors[:name]).to eq ['を入力してください']
       end
 
       it '空の文字列を入力する' do
-        location = build(:location, :designated, name: '')
+        location = build(:location, :for_departure, name: '')
         expect(location).to be_invalid
         expect(location.errors[:name]).to eq ['を入力してください']
       end
 
       it '50文字入力する' do
-        location = build(:location, :designated, name: 'a' * 50)
+        location = build(:location, :for_departure, name: 'a' * 50)
         expect(location).to be_valid
         expect(location.errors).to be_empty
       end
 
       it '51文字入力する' do
-        location = build(:location, :designated, name: 'a' * 51)
+        location = build(:location, :for_departure, name: 'a' * 51)
         expect(location).to be_invalid
         expect(location.errors[:name]).to eq ['は50文字以内で入力してください']
       end
@@ -36,43 +36,43 @@ RSpec.describe Location, type: :model do
 
     context '#latitude' do
       it 'nilを渡す' do
-        location = build(:location, :designated, latitude: nil)
+        location = build(:location, :for_departure, latitude: nil)
         expect(location).to be_invalid
         expect(location.errors[:latitude]).to eq ['を入力してください', 'は数値で入力してください']
       end
 
       it '空の文字列を入力する' do
-        location = build(:location, :designated, latitude: '')
+        location = build(:location, :for_departure, latitude: '')
         expect(location).to be_invalid
         expect(location.errors[:latitude]).to eq ['を入力してください', 'は数値で入力してください']
       end
 
       it '整数を入力する' do
-        location = build(:location, :designated, latitude: 1)
+        location = build(:location, :for_departure, latitude: 1)
         expect(location).to be_valid
         expect(location.errors).to be_empty
       end
 
       it '-91を入力する' do
-        location = build(:location, :designated, latitude: -91)
+        location = build(:location, :for_departure, latitude: -91)
         expect(location).to be_invalid
         expect(location.errors[:latitude]).to eq ['は-90度~90度以内に設定してください']
       end
 
       it '-90を入力する' do
-        location = build(:location, :designated, latitude: -90)
+        location = build(:location, :for_departure, latitude: -90)
         expect(location).to be_valid
         expect(location.errors).to be_empty
       end
 
       it '90を入力する' do
-        location = build(:location, :designated, latitude: 90)
+        location = build(:location, :for_departure, latitude: 90)
         expect(location).to be_valid
         expect(location.errors).to be_empty
       end
 
       it '91を入力する' do
-        location = build(:location, :designated, latitude: 91)
+        location = build(:location, :for_departure, latitude: 91)
         expect(location).to be_invalid
         expect(location.errors[:latitude]).to eq ['は-90度~90度以内に設定してください']
       end
@@ -80,43 +80,43 @@ RSpec.describe Location, type: :model do
 
     context '#longitude' do
       it 'nilを渡す' do
-        location = build(:location, :designated, longitude: nil)
+        location = build(:location, :for_departure, longitude: nil)
         expect(location).to be_invalid
         expect(location.errors[:longitude]).to eq ['を入力してください', 'は数値で入力してください']
       end
 
       it '空の文字列を入力する' do
-        location = build(:location, :designated, longitude: '')
+        location = build(:location, :for_departure, longitude: '')
         expect(location).to be_invalid
         expect(location.errors[:longitude]).to eq ['を入力してください', 'は数値で入力してください']
       end
 
       it '整数を入力する' do
-        location = build(:location, :designated, longitude: 1)
+        location = build(:location, :for_departure, longitude: 1)
         expect(location).to be_valid
         expect(location.errors).to be_empty
       end
 
       it '-181を入力する' do
-        location = build(:location, :designated, longitude: -181)
+        location = build(:location, :for_departure, longitude: -181)
         expect(location).to be_invalid
         expect(location.errors[:longitude]).to eq ['は-180度~180度以内に設定してください']
       end
 
       it '-180を入力する' do
-        location = build(:location, :designated, longitude: -180)
+        location = build(:location, :for_departure, longitude: -180)
         expect(location).to be_valid
         expect(location.errors).to be_empty
       end
 
       it '180を入力する' do
-        location = build(:location, :designated, longitude: 180)
+        location = build(:location, :for_departure, longitude: 180)
         expect(location).to be_valid
         expect(location.errors).to be_empty
       end
 
       it '181を入力する' do
-        location = build(:location, :designated, longitude: 181)
+        location = build(:location, :for_departure, longitude: 181)
         expect(location).to be_invalid
         expect(location.errors[:longitude]).to eq ['は-180度~180度以内に設定してください']
       end
@@ -124,25 +124,25 @@ RSpec.describe Location, type: :model do
 
     context '#address' do
       it 'nilを渡す' do
-        location = build(:location, :designated, address: nil)
+        location = build(:location, :for_departure, address: nil)
         expect(location).to be_invalid
         expect(location.errors[:address]).to eq ['を入力してください']
       end
 
       it '空の文字列を入力する' do
-        location = build(:location, :designated, address: '')
+        location = build(:location, :for_departure, address: '')
         expect(location).to be_invalid
         expect(location.errors[:address]).to eq ['を入力してください']
       end
 
       it '255文字入力する' do
-        location = build(:location, :designated, address: 'a' * 255)
+        location = build(:location, :for_departure, address: 'a' * 255)
         expect(location).to be_valid
         expect(location.errors).to be_empty
       end
 
       it '256文字入力する' do
-        location = build(:location, :designated, address: 'a' * 256)
+        location = build(:location, :for_departure, address: 'a' * 256)
         expect(location).to be_invalid
         expect(location.errors[:address]).to eq ['は255文字以内で入力してください']
       end
@@ -150,25 +150,25 @@ RSpec.describe Location, type: :model do
 
     context '#place_id' do
       it 'nilを渡す' do
-        location = build(:location, :designated, place_id: nil)
+        location = build(:location, :for_departure, place_id: nil)
         expect(location).to be_invalid
         expect(location.errors[:place_id]).to eq ['を入力してください']
       end
 
       it '空の文字列を入力する' do
-        location = build(:location, :designated, place_id: '')
+        location = build(:location, :for_departure, place_id: '')
         expect(location).to be_invalid
         expect(location.errors[:place_id]).to eq ['を入力してください']
       end
 
       it '255文字入力する' do
-        location = build(:location, :designated, place_id: 'a' * 255)
+        location = build(:location, :for_departure, place_id: 'a' * 255)
         expect(location).to be_valid
         expect(location.errors).to be_empty
       end
 
       it '256文字入力する' do
-        location = build(:location, :designated, place_id: 'a' * 256)
+        location = build(:location, :for_departure, place_id: 'a' * 256)
         expect(location).to be_invalid
         expect(location.errors[:place_id]).to eq ['は255文字以内で入力してください']
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,4 +63,5 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
   config.include LoginMacros
+  config.include VisitMacros
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,4 +64,5 @@ RSpec.configure do |config|
   config.include FactoryBot::Syntax::Methods
   config.include LoginMacros
   config.include VisitMacros
+  config.include MockMacros
 end

--- a/spec/support/mock_macros.rb
+++ b/spec/support/mock_macros.rb
@@ -6,7 +6,9 @@ module MockMacros
 
   def nearby_mock(result)
     nearby =
-      if result
+      if result.instance_of?(Array)
+        instance_double(Api::NearbyService, call: result)
+      elsif result.instance_of?(Hash)
         instance_double(Api::NearbyService, call: [result])
       else
         instance_double(Api::NearbyService, call: result)

--- a/spec/support/mock_macros.rb
+++ b/spec/support/mock_macros.rb
@@ -1,0 +1,16 @@
+module MockMacros
+  def geocode_mock(result)
+    geocode = instance_double(Api::GeocodeService, call: result)
+    allow(Api::GeocodeService).to receive(:new).and_return(geocode)
+  end
+
+  def nearby_mock(result)
+    nearby =
+      if result
+        instance_double(Api::NearbyService, call: [result])
+      else
+        instance_double(Api::NearbyService, call: result)
+      end
+    allow(Api::NearbyService).to receive(:new).and_return(nearby)
+  end
+end

--- a/spec/support/visit_macros.rb
+++ b/spec/support/visit_macros.rb
@@ -1,0 +1,49 @@
+module VisitMacros
+  def visit_saved_departures_page(departure)
+    login(departure.user)
+    sleep(0.1)
+    visit departures_path
+    sleep(0.1)
+    find('label[for=left]').click
+  end
+
+  def visit_edit_departure_page(departure)
+    visit_saved_departures_page(departure)
+    find('.fa.fa-chevron-down').click
+    click_link('編集')
+    sleep(0.1)
+  end
+
+  def visit_saved_destinations_page(destination)
+    login(destination.user)
+    sleep(0.1)
+    visit departures_path
+  end
+
+  def visit_histories_page(history)
+    login(history.user)
+    sleep(0.2)
+  end
+
+  def visit_new_departure_page(user)
+    login(user)
+    sleep(0.1)
+    visit new_departure_path
+  end
+
+  def visit_select_saved_departures_page(departure)
+    visit_new_departure_page(departure.user)
+    find('.fa.fa-folder-open.text-2xl').click
+  end
+
+  def visit_select_history_departure_page(departure)
+    visit_new_departure_page(departure.user)
+    find('.fa.fa-history.text-2xl').click
+  end
+
+  def visit_input_terms_page(departure)
+    visit_new_departure_page(departure.user)
+    find('.fa.fa-folder-open.text-2xl').click
+    click_link '出発'
+  end
+end

--- a/spec/support/visit_macros.rb
+++ b/spec/support/visit_macros.rb
@@ -46,4 +46,11 @@ module VisitMacros
     find('.fa.fa-folder-open.text-2xl').click
     click_link '出発'
   end
+
+  def visit_search_results_page(departure)
+    visit_input_terms_page(departure)
+    fill_in '距離(1000m~5000m)', with: '5000'
+    click_button '検索'
+    sleep(0.1)
+  end
 end

--- a/spec/system/profile/histories_spec.rb
+++ b/spec/system/profile/histories_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Profile::Histories", type: :system do
         expect(page).to have_content "#{history.moving_distance}m"
         expect(page).to have_content I18n.l(history.start_time, format: :short)
         expect(page).to have_content "#{history.decorate.moving_time}分"
-        expect(page).to have_content history.destination.departure.name
+        expect(page).to have_content history.departure.name
       end
 
       it 'リンク関連が正しく表示されている' do
@@ -57,7 +57,7 @@ RSpec.describe "Profile::Histories", type: :system do
 
     context '複数のユーザーの履歴を作成する' do
       it '自分の履歴のみ表示される' do
-        saved_own = create(:history, user:)
+        saved_own = history
         saved_other = create(:history, user: other)
         visit_histories_page(saved_own)
         expect(page).to have_content saved_own.destination.name

--- a/spec/system/profile/histories_spec.rb
+++ b/spec/system/profile/histories_spec.rb
@@ -51,7 +51,9 @@ RSpec.describe "Profile::Histories", type: :system do
         expect(page).to have_link '削除', href: history_path(history.uuid, route: 'profile_page')
         click_link '編集'
         expect(page).to have_link '取消', href: cancel_history_path(history.uuid, route: 'profile_page')
+        expect(page).to have_button '更新'
         expect(find('form')['action']).to be_include history_path(history.uuid, route: 'profile_page')
+        expect(find('input[name="_method"]', visible: false)['value']).to eq 'patch'
       end
     end
 

--- a/spec/system/profile/histories_spec.rb
+++ b/spec/system/profile/histories_spec.rb
@@ -4,11 +4,6 @@ RSpec.describe "Profile::Histories", type: :system do
   let(:history) { create(:history, :commented) }
   let(:user) { create(:user) }
 
-  def visit_histories_page(history)
-    login(history.user)
-    sleep(0.2)
-  end
-
   describe 'Page' do
     context '履歴のページにアクセスする' do
       it '情報が正しく表示されている' do

--- a/spec/system/profile/settings_spec.rb
+++ b/spec/system/profile/settings_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe "Profile::Settings", type: :system do
       end
     end
 
-    describe 'ユーザーのプロフィールを編集' do
+    describe 'Edit' do
       before do
         find('label[for=right]').click
         click_link '編集'

--- a/spec/system/saved/departures_spec.rb
+++ b/spec/system/saved/departures_spec.rb
@@ -91,7 +91,7 @@ RSpec.describe "Saved::Departures", type: :system do
           click_button '更新'
           expect(page).to have_content '出発地を更新しました'
           expect(page).to have_content build_departure.name
-          expect(page).to have_content build_departure.address
+          expect(page).to have_content Settings.geocode.result[:address]
         end
       end
 

--- a/spec/system/saved/departures_spec.rb
+++ b/spec/system/saved/departures_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe "Saved::Departures", type: :system do
 
     context '複数のユーザーの保存済み出発地を作成する' do
       it '自分の保存済み出発地のみ表示される' do
-        saved_own = create(:departure, user:, is_saved: true)
+        saved_own = departure
         saved_other = create(:departure, user: other, is_saved: true)
         visit_saved_departures_page(saved_own)
         expect(page).to have_content saved_own.name
@@ -61,7 +61,7 @@ RSpec.describe "Saved::Departures", type: :system do
 
     context '保存済み・未保存出発地を作成する' do
       it '保存済み出発地のみ表示される' do
-        saved_departure = create(:departure, user:, is_saved: true)
+        saved_departure = departure
         not_saved_departure = create(:departure, user:, is_saved: false)
         visit_saved_departures_page(saved_departure)
         expect(page).to have_content saved_departure.name

--- a/spec/system/saved/departures_spec.rb
+++ b/spec/system/saved/departures_spec.rb
@@ -67,23 +67,21 @@ RSpec.describe "Saved::Departures", type: :system do
 
   describe 'Edit' do
     let(:another_departure) { create(:departure, :another, is_saved: true) }
-    let(:for_result) { build(:location, :for_departure) }
+    let(:for_geocode_result) { build(:location, :for_departure) }
+    let(:geocode_result) { for_geocode_result.attributes.compact.symbolize_keys }
 
     describe 'Validations' do
       before { visit_edit_departure_page(another_departure) }
 
       context '正常な値を入力する' do
         it '保存済み出発地の更新に成功し、一覧が表示される' do
-          result = for_result.attributes.compact.symbolize_keys
-          geocode = instance_double(Api::GeocodeService, call: result)
-          allow(Api::GeocodeService).to receive(:new).and_return(geocode)
-
-          fill_in '名称', with: for_result.name
-          fill_in '住所', with: for_result.address
+          geocode_mock(geocode_result)
+          fill_in '名称', with: for_geocode_result.name
+          fill_in '住所', with: for_geocode_result.address
           click_button '更新'
           expect(page).to have_content '出発地を更新しました'
-          expect(page).to have_content result[:name]
-          expect(page).to have_content result[:address]
+          expect(page).to have_content geocode_result[:name]
+          expect(page).to have_content geocode_result[:address]
         end
       end
 
@@ -99,15 +97,12 @@ RSpec.describe "Saved::Departures", type: :system do
 
         context '名称を50文字入力する' do
           it '保存済み出発地の更新に成功し、一覧が表示される' do
-            result = for_result.attributes.compact.symbolize_keys
-            result[:name] = 'a' * 50
-            geocode = instance_double(Api::GeocodeService, call: result)
-            allow(Api::GeocodeService).to receive(:new).and_return(geocode)
-
-            fill_in '名称', with: result[:name]
+            geocode_result[:name] = 'a' * 50
+            geocode_mock(geocode_result)
+            fill_in '名称', with: geocode_result[:name]
             click_button '更新'
             expect(page).to have_content '出発地を更新しました'
-            expect(page).to have_content result[:name]
+            expect(page).to have_content geocode_result[:name]
           end
         end
 
@@ -134,14 +129,11 @@ RSpec.describe "Saved::Departures", type: :system do
         context '住所を255文字入力する' do
           it '保存済み出発地の更新に成功し、一覧が表示される' do
             # 実際に存在する255文字の住所を打ち込んだという仮定
-            result = for_result.attributes.compact.symbolize_keys
-            geocode = instance_double(Api::GeocodeService, call: result)
-            allow(Api::GeocodeService).to receive(:new).and_return(geocode)
-
+            geocode_mock(geocode_result)
             fill_in '住所', with: 'a' * 255
             click_button '更新'
             expect(page).to have_content '出発地を更新しました'
-            expect(page).to have_content result[:address]
+            expect(page).to have_content geocode_result[:address]
           end
         end
 
@@ -241,9 +233,7 @@ RSpec.describe "Saved::Departures", type: :system do
   describe 'Failure' do
     context '入力された住所が存在しないため、取得に失敗する' do
       it 'エラーメッセージが表示され、編集状態に戻る' do
-        geocode = instance_double(Api::GeocodeService, call: false)
-        allow(Api::GeocodeService).to receive(:new).and_return(geocode)
-
+        geocode_mock(false)
         visit_edit_departure_page(departure)
         address = 'failure'
         fill_in '住所', with: address

--- a/spec/system/saved/departures_spec.rb
+++ b/spec/system/saved/departures_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe "Saved::Departures", type: :system do
         context '住所を255文字入力する' do
           it '保存済み出発地の更新に成功し、一覧が表示される', vcr: false do
             # 実際に存在する255文字の住所を打ち込んだという仮定のため、mockを使用
-            result = build(:location, :designated).attributes.compact.symbolize_keys
+            result = build(:location, :for_departure).attributes.compact.symbolize_keys
             geocode = instance_double(Api::GeocodeService, call: result)
             allow(Api::GeocodeService).to receive(:new).and_return(geocode)
 

--- a/spec/system/saved/departures_spec.rb
+++ b/spec/system/saved/departures_spec.rb
@@ -241,4 +241,20 @@ RSpec.describe "Saved::Departures", type: :system do
       end
     end
   end
+
+  describe 'Failure' do
+    context '入力された住所が存在しないため、取得に失敗する' do
+      it 'エラーメッセージが表示され、編集状態に戻る' do
+        geocode = instance_double(Api::GeocodeService, call: false)
+        allow(Api::GeocodeService).to receive(:new).and_return(geocode)
+
+        visit_edit_departure_page(departure)
+        address = 'failure'
+        fill_in '住所', with: address
+        click_button '更新'
+        expect(page).to have_content '位置情報の取得に失敗しました'
+        expect(page).to have_field '住所', with: address
+      end
+    end
+  end
 end

--- a/spec/system/saved/departures_spec.rb
+++ b/spec/system/saved/departures_spec.rb
@@ -31,6 +31,7 @@ RSpec.describe "Saved::Departures", type: :system do
 
     context '１つの出発地を保存する' do
       before { visit_saved_departures_page(departure) }
+
       it '情報が正しく表示されている' do
         expect(current_path).to eq departures_path
         expect(page).to have_content departure.name
@@ -45,7 +46,9 @@ RSpec.describe "Saved::Departures", type: :system do
         expect(page).to have_link '削除', href: departure_path(departure.uuid)
         click_link '編集'
         expect(page).to have_link '取消', href: departure_path(departure.uuid)
+        expect(page).to have_button '更新'
         expect(find('form')['action']).to be_include departure_path(departure.uuid)
+        expect(find('input[name="_method"]', visible: false)['value']).to eq 'patch'
       end
     end
 

--- a/spec/system/saved/departures_spec.rb
+++ b/spec/system/saved/departures_spec.rb
@@ -4,14 +4,6 @@ RSpec.describe "Saved::Departures", type: :system do
   let(:departure) { create(:departure, is_saved: true) }
   let(:user) { create(:user) }
 
-  def visit_saved_departures_page(departure)
-    login(departure.user)
-    sleep(0.1)
-    visit departures_path
-    sleep(0.1)
-    find('label[for=left]').click
-  end
-
   describe 'Page' do
     context '保存済み出発地のページにアクセスする' do
       it '情報が正しく表示されている' do
@@ -71,13 +63,6 @@ RSpec.describe "Saved::Departures", type: :system do
         expect(page).not_to have_content not_saved_departure.name
       end
     end
-  end
-
-  def visit_edit_departure_page(departure)
-    visit_saved_departures_page(departure)
-    find('.fa.fa-chevron-down').click
-    click_link('編集')
-    sleep(0.1)
   end
 
   describe 'Edit' do

--- a/spec/system/saved/departures_spec.rb
+++ b/spec/system/saved/departures_spec.rb
@@ -138,14 +138,14 @@ RSpec.describe "Saved::Departures", type: :system do
         context '住所を255文字入力する' do
           it '保存済み出発地の更新に成功し、一覧が表示される', vcr: false do
             # 実際に存在する255文字の住所を打ち込んだという仮定のため、mockを使用
-            result = build(:location, :designated).attributes.compact
+            result = build(:location, :designated).attributes.compact.symbolize_keys
             geocode = instance_double(Api::GeocodeService, call: result)
             allow(Api::GeocodeService).to receive(:new).and_return(geocode)
 
             fill_in '住所', with: 'a' * 255
             click_button '更新'
             expect(page).to have_content '出発地を更新しました'
-            expect(page).to have_content result['address']
+            expect(page).to have_content result[:address]
           end
         end
 

--- a/spec/system/saved/destinations_spec.rb
+++ b/spec/system/saved/destinations_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe "Saved::Destinations", type: :system do
 
     context '複数のユーザーの保存済み目的地を作成する' do
       it '自分の保存済み目的地のみ表示される' do
-        saved_own = create(:destination, user:, is_saved: true)
+        saved_own = destination
         saved_other = create(:destination, user: other, is_saved: true)
         visit_saved_destinations_page(saved_own)
         expect(page).to have_content saved_own.name
@@ -64,7 +64,7 @@ RSpec.describe "Saved::Destinations", type: :system do
 
     context '保存済み・未保存目的地を作成する' do
       it '保存済み目的地のみ表示される' do
-        saved_destination = create(:destination, user:, is_saved: true)
+        saved_destination = destination
         not_saved_destination = create(:destination, user:, is_saved: false)
         visit_saved_destinations_page(saved_destination)
         expect(page).to have_content saved_destination.name

--- a/spec/system/saved/destinations_spec.rb
+++ b/spec/system/saved/destinations_spec.rb
@@ -4,12 +4,6 @@ RSpec.describe "Saved::Destinations", type: :system do
   let(:destination) { create(:destination, :published_comment) }
   let(:user) { create(:user) }
 
-  def visit_saved_destinations_page(destination)
-    login(destination.user)
-    sleep(0.1)
-    visit departures_path
-  end
-
   describe 'Page' do
     context '保存済み目的地のページにアクセスする' do
       it '情報が正しく表示されている' do

--- a/spec/system/saved/destinations_spec.rb
+++ b/spec/system/saved/destinations_spec.rb
@@ -48,7 +48,9 @@ RSpec.describe "Saved::Destinations", type: :system do
         expect(page).to have_link '削除', href: destination_path(destination.uuid, route: 'saved_page')
         click_link '編集'
         expect(page).to have_link '取消', href: destination_path(destination.uuid, route: 'saved_page')
+        expect(page).to have_button '更新'
         expect(find('form')['action']).to be_include destination_path(destination.uuid, route: 'saved_page')
+        expect(find('input[name="_method"]', visible: false)['value']).to eq 'patch'
       end
     end
 

--- a/spec/system/search/input_departures_spec.rb
+++ b/spec/system/search/input_departures_spec.rb
@@ -5,12 +5,6 @@ RSpec.describe "Search::InputDepartures", type: :system do
   let(:result_address) { build(:departure_form).address }
   let(:user) { create(:user) }
 
-  def visit_new_departure_page
-    login(user)
-    sleep(0.1)
-    visit new_departure_path
-  end
-
   describe 'Page' do
     context '出発地を入力するページにアクセスする' do
       it '情報が正しく表示されている' do
@@ -31,7 +25,7 @@ RSpec.describe "Search::InputDepartures", type: :system do
   end
 
   describe 'Contents' do
-    before { visit_new_departure_page }
+    before { visit_new_departure_page(user) }
 
     context '出発地を入力するページにアクセスする' do
       it 'リンク関連が正しく表示されている' do
@@ -46,7 +40,7 @@ RSpec.describe "Search::InputDepartures", type: :system do
   describe 'Validations' do
     let(:for_result) { build(:location, :for_departure) }
 
-    before { visit_new_departure_page }
+    before { visit_new_departure_page(user) }
 
     context '正常な値を入力する（保存する）' do
       it '出発地の作成に成功し、目的地の条件入力ページに遷移する' do
@@ -165,7 +159,7 @@ RSpec.describe "Search::InputDepartures", type: :system do
   end
 
   describe 'Form' do
-    before { visit_new_departure_page }
+    before { visit_new_departure_page(user) }
 
     context '名称を入力し、取得に失敗する' do
       it 'フォームから入力した名称が消えていない' do
@@ -194,7 +188,7 @@ RSpec.describe "Search::InputDepartures", type: :system do
         geocode = instance_double(Api::GeocodeService, call: false)
         allow(Api::GeocodeService).to receive(:new).and_return(geocode)
 
-        visit_new_departure_page
+        visit_new_departure_page(user)
         fill_in '名称', with: departure_form.name
         fill_in '住所', with: departure_form.address
         click_button '決定'

--- a/spec/system/search/input_departures_spec.rb
+++ b/spec/system/search/input_departures_spec.rb
@@ -30,6 +30,19 @@ RSpec.describe "Search::InputDepartures", type: :system do
     end
   end
 
+  describe 'Contents' do
+    before { visit_new_departure_page }
+
+    context '出発地を入力するページにアクセスする' do
+      it 'リンク関連が正しく表示されている' do
+        expect(page).to have_button '決定'
+        expect(find('form')['action']).to be_include departures_path
+        expect(find('form')['method']).to eq 'post'
+        expect(page).not_to have_selector("input[name='_method']", visible: false)
+      end
+    end
+  end
+
   describe 'Validations' do
     let(:for_result) { build(:location, :for_departure) }
 
@@ -46,6 +59,8 @@ RSpec.describe "Search::InputDepartures", type: :system do
         fill_in '住所', with: for_result.address
         check '保存する'
         click_button '決定'
+        sleep(0.1)
+        expect(current_path).to eq new_search_path
         expect(page).to have_content '出発地を保存しました'
         expect(page).to have_content result[:name]
         expect(page).to have_content result[:address]
@@ -62,6 +77,8 @@ RSpec.describe "Search::InputDepartures", type: :system do
         fill_in '住所', with: for_result.address
         uncheck '保存する'
         click_button '決定'
+        sleep(0.1)
+        expect(current_path).to eq new_search_path
         expect(page).not_to have_content '出発地を保存しました'
         expect(page).to have_content result[:name]
         expect(page).to have_content result[:address]
@@ -75,6 +92,7 @@ RSpec.describe "Search::InputDepartures", type: :system do
         it '出発地の取得に失敗し、出発地入力状態に戻る'do
           fill_in '名称', with: ''
           click_button '決定'
+          expect(current_path).to eq new_departure_path
           expect(page).to have_content '名称を入力してください'
           expect(page).to have_content '入力情報に誤りがあります'
         end
@@ -89,6 +107,8 @@ RSpec.describe "Search::InputDepartures", type: :system do
 
           fill_in '名称', with: result[:name]
           click_button '決定'
+          sleep(0.1)
+          expect(current_path).to eq new_search_path
           expect(page).to have_content result[:name]
         end
       end
@@ -97,6 +117,7 @@ RSpec.describe "Search::InputDepartures", type: :system do
         it '出発地の取得に失敗し、出発地入力状態に戻る' do
           fill_in '名称', with: 'a' * 51
           click_button '決定'
+          expect(current_path).to eq new_departure_path
           expect(page).to have_content '名称は50文字以内で入力してください'
           expect(page).to have_content '入力情報に誤りがあります'
         end
@@ -110,6 +131,7 @@ RSpec.describe "Search::InputDepartures", type: :system do
         it '出発地の取得に失敗し、出発地入力状態に戻る' do
           fill_in '住所', with: ''
           click_button '決定'
+          expect(current_path).to eq new_departure_path
           expect(page).to have_content '住所を入力してください'
           expect(page).to have_content '入力情報に誤りがあります'
         end
@@ -124,6 +146,8 @@ RSpec.describe "Search::InputDepartures", type: :system do
 
           fill_in '住所', with: 'a' * 255
           click_button '決定'
+          sleep(0.1)
+          expect(current_path).to eq new_search_path
           expect(page).to have_content result[:address]
         end
       end
@@ -132,6 +156,7 @@ RSpec.describe "Search::InputDepartures", type: :system do
         it '出発地の取得に失敗し、出発地入力状態に戻る' do
           fill_in '住所', with: 'a' * 256
           click_button '決定'
+          expect(current_path).to eq new_departure_path
           expect(page).to have_content '住所は255文字以内で入力してください'
           expect(page).to have_content '入力情報に誤りがあります'
         end

--- a/spec/system/search/input_departures_spec.rb
+++ b/spec/system/search/input_departures_spec.rb
@@ -1,0 +1,150 @@
+require 'rails_helper'
+
+RSpec.describe "Search::InputDepartures", type: :system do
+  let(:departure_form) { build(:departure_form) }
+  let(:result_address) { build(:departure_form).address }
+  let(:user) { create(:user) }
+
+  describe 'Page' do
+    context '出発地を入力するページにアクセスする' do
+      it '情報が正しく表示されている' do
+        login(user)
+        sleep(0.1)
+        find('.fa.fa-search.nav-icon').click
+        expect(current_path).to eq new_departure_path
+        expect(page).to have_content '出発地'
+        expect(page).to have_content '入力'
+        expect(page).to have_content '保存'
+        expect(page).to have_content '履歴'
+        expect(page).to have_link '現在地取得'
+        expect(page).to have_field '名称', with: ''
+        expect(page).to have_field '住所', with: ''
+        expect(page).to have_unchecked_field '保存する'
+      end
+    end
+  end
+
+  describe 'Inputs' do
+    before do
+      login(user)
+      sleep(0.1)
+      visit new_departure_path
+    end
+
+    describe 'Validations', vcr: { cassette_name: 'geocode/success' } do
+      context '正常な値を入力する（保存する）' do
+        it '出発地の作成に成功し、目的地の条件入力ページに遷移する' do
+          fill_in '名称', with: departure_form.name
+          fill_in '住所', with: departure_form.address
+          check '保存する'
+          click_button '決定'
+          expect(page).to have_content '出発地を保存しました'
+          expect(page).to have_content departure_form.name
+          expect(page).to have_content Settings.geocode.result[:address]
+        end
+      end
+
+      context '正常な値を入力する（保存しない）' do
+        it '出発地の取得に成功し、目的地の条件入力ページに遷移する' do
+          fill_in '名称', with: departure_form.name
+          fill_in '住所', with: departure_form.address
+          uncheck '保存する'
+          click_button '決定'
+          expect(page).not_to have_content '出発地を保存しました'
+          expect(page).to have_content departure_form.name
+          expect(page).to have_content Settings.geocode.result[:address]
+        end
+      end
+
+      describe '#name' do
+        before { fill_in '住所', with: departure_form.address }
+
+        context '名称を空白にする' do
+          it '出発地の取得に失敗し、出発地入力状態に戻る'do
+            fill_in '名称', with: ''
+            click_button '決定'
+            expect(page).to have_content '名称を入力してください'
+            expect(page).to have_content '入力情報に誤りがあります'
+          end
+        end
+
+        context '名称を50文字入力する' do
+          it '出発地の取得に成功し、目的地の条件入力ページに遷移する' do
+            name = 'a' * 50
+            fill_in '名称', with: name
+            click_button '決定'
+            expect(page).to have_content name
+          end
+        end
+
+        context '名称を51文字入力する' do
+          it '出発地の取得に失敗し、出発地入力状態に戻る' do
+            fill_in '名称', with: 'a' * 51
+            click_button '決定'
+            expect(page).to have_content '名称は50文字以内で入力してください'
+            expect(page).to have_content '入力情報に誤りがあります'
+          end
+        end
+      end
+
+      describe '#address' do
+        before { fill_in '名称', with: departure_form.name }
+
+        context '住所を空白にする' do
+          it '出発地の取得に失敗し、出発地入力状態に戻る' do
+            fill_in '住所', with: ''
+            click_button '決定'
+            expect(page).to have_content '住所を入力してください'
+            expect(page).to have_content '入力情報に誤りがあります'
+          end
+        end
+
+        context '住所を255文字入力する' do
+          it '出発地の取得に成功し、目的地の条件入力ページに遷移する', vcr: false do
+            # 実際に存在する255文字の住所を打ち込んだという仮定のため、mockを使用
+            result = build(:location, :designated).attributes.compact.symbolize_keys
+            geocode = instance_double(Api::GeocodeService, call: result)
+            allow(Api::GeocodeService).to receive(:new).and_return(geocode)
+
+            fill_in '住所', with: 'a' * 255
+            click_button '決定'
+            expect(page).to have_content result[:address]
+          end
+        end
+
+        context '住所を256文字入力する' do
+          it '出発地の取得に失敗し、出発地入力状態に戻る' do
+            fill_in '住所', with: 'a' * 256
+            click_button '決定'
+            expect(page).to have_content '住所は255文字以内で入力してください'
+            expect(page).to have_content '入力情報に誤りがあります'
+          end
+        end
+      end
+    end
+
+    describe 'Form' do
+      context '名称を入力し、取得に失敗する' do
+        it 'フォームから入力した名称が消えていない' do
+          name = 'a' * 51
+          fill_in '名称', with: name
+          fill_in '住所', with: departure_form.address
+          click_button '決定'
+          expect(page).to have_field '名称', with: name
+        end
+      end
+
+      context '住所を入力し、取得に失敗する' do
+        it 'フォームから入力した住所が消えていない' do
+          address = 'a' * 256
+          fill_in '名称', with: departure_form.name
+          fill_in '住所', with: address
+          click_button '決定'
+          expect(page).to have_field '住所', with: address
+        end
+      end
+    end
+  end
+
+  # describe 'GetCurrentLocation'
+end

--- a/spec/system/search/input_departures_spec.rb
+++ b/spec/system/search/input_departures_spec.rb
@@ -102,7 +102,7 @@ RSpec.describe "Search::InputDepartures", type: :system do
         context '住所を255文字入力する' do
           it '出発地の取得に成功し、目的地の条件入力ページに遷移する', vcr: false do
             # 実際に存在する255文字の住所を打ち込んだという仮定のため、mockを使用
-            result = build(:location, :designated).attributes.compact.symbolize_keys
+            result = build(:location, :for_departure).attributes.compact.symbolize_keys
             geocode = instance_double(Api::GeocodeService, call: result)
             allow(Api::GeocodeService).to receive(:new).and_return(geocode)
 

--- a/spec/system/search/input_terms_spec.rb
+++ b/spec/system/search/input_terms_spec.rb
@@ -5,18 +5,6 @@ RSpec.describe "Search::InputTerms", type: :system do
   let(:departure_form) { build(:departure_form) }
   let(:user) { create(:user) }
 
-  def visit_new_departure_page(departure)
-    login(departure.user)
-    sleep(0.1)
-    visit new_departure_path
-  end
-
-  def visit_input_terms_page(departure)
-    visit_new_departure_page(departure)
-    find('.fa.fa-folder-open.text-2xl').click
-    click_link '出発'
-  end
-
   describe 'Page' do
     context '条件を入力するページにアクセスする' do
       it '情報が正しく表示されている' do

--- a/spec/system/search/input_terms_spec.rb
+++ b/spec/system/search/input_terms_spec.rb
@@ -46,7 +46,10 @@ RSpec.describe "Search::InputTerms", type: :system do
       end
 
       it 'リンク関連が正しく表示されている' do
+        expect(page).to have_button '検索'
         expect(find('form')['action']).to be_include searches_path
+        expect(find('form')['method']).to eq 'post'
+        expect(page).not_to have_selector("input[name='_method']", visible: false)
       end
     end
 

--- a/spec/system/search/input_terms_spec.rb
+++ b/spec/system/search/input_terms_spec.rb
@@ -1,0 +1,77 @@
+require 'rails_helper'
+
+RSpec.describe "Search::InputTerms", type: :system do
+  let(:departure) { create(:departure, is_saved: true, user:) }
+  let(:departure_form) { build(:departure_form) }
+  let(:user) { create(:user) }
+
+  def visit_new_departure_page(departure)
+    login(departure.user)
+    sleep(0.1)
+    visit new_departure_path
+  end
+
+  def visit_input_terms_page(departure)
+    visit_new_departure_page(departure)
+    find('.fa.fa-folder-open.text-2xl').click
+    click_link '出発'
+  end
+
+  describe 'Page' do
+    context '条件を入力するページにアクセスする' do
+      it '情報が正しく表示されている' do
+        login(departure.user)
+        sleep(0.1)
+        find('.fa.fa-search.nav-icon').click
+        find('.fa.fa-folder-open.text-2xl').click
+        click_link '出発'
+        expect(current_path).to eq new_search_path
+        expect(page).to have_content '条件'
+        expect(page).to have_content '出発地'
+        expect(page).to have_field '距離(1000m~5000m)', with: ''
+        expect(page).to have_select '種類', selected: 'コンビニエンスストア'
+      end
+    end
+  end
+
+  describe 'Contents' do
+    context '保存済み出発地を選択し、条件入力ページに遷移する' do
+      before { visit_input_terms_page(departure) }
+
+      it '情報が正しく表示されている' do
+        expect(current_path).to eq new_search_path
+        expect(page).to have_content departure.name
+        expect(page).to have_content departure.address
+        expect(page).to have_content I18n.l(departure.created_at, format: :short)
+      end
+
+      it 'リンク関連が正しく表示されている' do
+        expect(find('form')['action']).to be_include searches_path
+      end
+    end
+
+    context '出発地を保存せず、条件入力ページに遷移する', vcr: { cassette_name: 'geocode/success' } do
+      before do
+        login(user)
+        sleep(0.1)
+        visit new_departure_path
+        fill_in '名称', with: departure_form.name
+        fill_in '住所', with: departure_form.address
+        uncheck '保存する'
+        click_button '決定'
+        sleep(0.1)
+      end
+
+      it '情報が正しく表示されている' do
+        expect(current_path).to eq new_search_path
+        expect(page).to have_content departure_form.name
+        expect(page).to have_content departure_form.address
+        expect(page).to have_content '未保存'
+      end
+
+      it 'リンク関連が正しく表示されている' do
+        expect(find('form')['action']).to be_include searches_path
+      end
+    end
+  end
+end

--- a/spec/system/search/input_terms_spec.rb
+++ b/spec/system/search/input_terms_spec.rb
@@ -79,9 +79,9 @@ RSpec.describe "Search::InputTerms", type: :system do
     let(:result) { Settings.nearby_result.radius_1000.to_hash }
 
     before do
-      visit_input_terms_page(departure)
       nearby = instance_double(Api::NearbyService, call: [result])
       allow(Api::NearbyService).to receive(:new).and_return(nearby)
+      visit_input_terms_page(departure)
     end
 
     context '正常な値を入力する' do
@@ -187,9 +187,17 @@ RSpec.describe "Search::InputTerms", type: :system do
     end
   end
 
-  xdescribe 'Failure' do
+  describe 'Failure' do
     context '条件に合致する目的地が存在しないため、検索に失敗する' do
       it 'エラーメッセージが表示され、条件入力ページに戻る' do
+        nearby = instance_double(Api::NearbyService, call: false)
+        allow(Api::NearbyService).to receive(:new).and_return(nearby)
+        visit_input_terms_page(departure)
+
+        fill_in '距離(1000m~5000m)', with: 1000
+        click_button '検索'
+        expect(current_path).to eq new_search_path
+        expect(page).to have_content '目的地が見つかりませんでした'
       end
     end
   end

--- a/spec/system/search/results_spec.rb
+++ b/spec/system/search/results_spec.rb
@@ -1,0 +1,41 @@
+require 'rails_helper'
+
+RSpec.describe "Search::Results", type: :system do
+  let(:departure) { create(:departure, is_saved: true, user:) }
+  let(:nearby_result) { Settings.nearby_result.radius_1000.to_hash }
+  let(:user) { create(:user) }
+
+  describe 'Page' do
+    context '検索結果ページにアクセスする' do
+      it '情報が正しく表示されている' do
+        nearby_mock(nearby_result)
+        visit_search_results_page(departure)
+        expect(current_path).to eq searches_path
+        expect(page).to have_content '検索結果'
+        expect(page).to have_content 'コメント'
+        expect(page).to have_content '保存済み'
+      end
+    end
+  end
+
+  describe 'Search' do
+    context 'Contents' do
+      context '目的地の検索に成功し、検索結果ページにアクセスする' do
+        before do
+          nearby_mock(nearby_result)
+          visit_search_results_page(departure)
+        end
+
+        it '情報が正しく表示されている' do
+          expect(current_path).to eq searches_path
+          expect(page).to have_content nearby_result[:variable][:name]
+          expect(page).to have_content nearby_result[:fixed][:address]
+        end
+
+        it 'リンク関連が正しく表示されている' do
+          expect(page).to have_link '決定', href: new_destination_path(destination: nearby_result[:variable][:uuid])
+        end
+      end
+    end
+  end
+end

--- a/spec/system/search/results_spec.rb
+++ b/spec/system/search/results_spec.rb
@@ -38,4 +38,63 @@ RSpec.describe "Search::Results", type: :system do
       end
     end
   end
+
+  describe 'Comment' do
+    context 'Contents' do
+      context '近くに他ユーザーコメントした目的地がある検索結果ページにアクセスする' do
+        let!(:published_comment_destination) { create(:destination, :published_comment) }
+        let(:uuid) { 'c3ed4142-499f-4eaa-af7d-d27aad97035f' }
+
+        before do
+          # 他人の目的地を表示する際に、データベースに保存されているuuidが表示されないか検証するため
+          allow(SecureRandom).to receive(:uuid).and_return(uuid)
+          nearby_mock(nearby_result)
+          visit_search_results_page(departure)
+          find('.fa.fa-commenting.text-2xl').click
+        end
+
+        it '情報が正しく表示されている' do
+          expect(current_path).to eq searches_path
+          expect(page).to have_content published_comment_destination.name
+          expect(page).to have_content published_comment_destination.address
+          expect(page).to have_content published_comment_destination.comment
+          expect(page).to have_css '.fa.fa-eye'
+          expect(page).not_to have_css '.fa.fa-eye-slash'
+          expect(page).to have_css '.fa.fa-commenting'
+        end
+
+        it 'リンク関連が正しく表示されている' do
+          expect(page).to have_link '決定', href: new_destination_path(destination: uuid)
+          expect(page).not_to have_link '決定', href: new_destination_path(destination: published_comment_destination.uuid)
+        end
+      end
+
+      context '他ユーザーが同じ目的地に複数コメントした検索結果ページにアクセスする' do
+        let!(:published_comment_destination) { create(:destination, :published_comment) }
+        let!(:another_published_comment_destination) { create(:destination, :published_comment) }
+
+        it '該当目的地のコメントが箇条書きで表示される' do
+          nearby_mock(nearby_result)
+          visit_search_results_page(departure)
+          find('.fa.fa-commenting.text-2xl').click
+          expect(page).to have_content published_comment_destination.comment
+          expect(page).to have_content another_published_comment_destination.comment
+          expect(page).to have_css '.fa.fa-eye'
+          expect(page).not_to have_css '.fa.fa-eye-slash'
+          expect(page).to have_css '.fa.fa-commenting'
+        end
+      end
+
+      context '他ユーザーの非公開コメントの目的地が存在する状態で検索結果ページにアクセスする' do
+        let!(:another_not_published_comment_destination) { create(:destination, :not_published_comment) }
+
+        it '該当目的地が表示されない' do
+          nearby_mock(nearby_result)
+          visit_search_results_page(departure)
+          find('.fa.fa-commenting.text-2xl').click
+          expect(page).not_to have_content another_not_published_comment_destination.name
+        end
+      end
+    end
+  end
 end

--- a/spec/system/search/results_spec.rb
+++ b/spec/system/search/results_spec.rb
@@ -179,30 +179,60 @@ RSpec.describe "Search::Results", type: :system do
 
   describe 'Other' do
     context 'Contents' do
-      context '検索結果と公開コメントで重複した目的地がある' do
+      context '検索結果と公開コメントでplace_idが重複した目的地がある' do
         it 'コメントの枠で表示されている' do
+          nearby_mock(nearby_result)
+          location = create(:location, :for_departure, place_id: nearby_result[:fixed][:place_id])
+          published_comment_destination = create(:destination, :published_comment, location:)
+          visit_search_results_page(departure)
+          expect(page).not_to have_content nearby_result[:variable][:name]
+          find('.fa.fa-commenting.text-2xl').click
+          expect(page).to have_content published_comment_destination.name
         end
       end
 
-      context '公開コメントと保存済みで重複した目的地がある' do
+      context '公開コメントと保存済みでplace_idが重複した目的地がある' do
         it '保存済みの枠で表示されている' do
+          nearby_mock(nearby_result)
+          published_comment_destination = create(:destination, :published_comment)
+          location = create(:location, :for_departure, place_id: published_comment_destination.place_id)
+          saved_destination = create(:destination, is_saved: true, user:, departure:, location:)
+          visit_search_results_page(saved_destination.departure)
+          find('.fa.fa-commenting.text-2xl').click
+          expect(page).not_to have_content published_comment_destination.name
+          find('.fa.fa-folder-open.text-2xl').click
+          expect(page).to have_content saved_destination.name
         end
       end
 
-      context '検索結果と保存済みで重複した目的地がある' do
+      context '検索結果と保存済みでplace_idが重複した目的地がある' do
         it '保存済みの枠で表示されている' do
+          nearby_mock(nearby_result)
+          location = create(:location, :for_departure, place_id: nearby_result[:fixed][:place_id])
+          saved_destination = create(:destination, is_saved: true, user:, departure:, location:)
+          visit_search_results_page(saved_destination.departure)
+          expect(page).not_to have_content nearby_result[:variable][:name]
+          find('.fa.fa-folder-open.text-2xl').click
+          expect(page).to have_content saved_destination.name
         end
       end
 
-      context '検索結果と公開コメントと保存済みで重複した目的地がある' do
+      context '検索結果と公開コメントと保存済みでplace_idが重複した目的地がある' do
         it '保存済みの枠で表示されている' do
+          nearby_mock(nearby_result)
+          location = create(:location, :for_departure, place_id: nearby_result[:fixed][:place_id])
+          published_comment_destination = create(:destination, :published_comment, location:)
+          saved_destination = create(:destination, is_saved: true, user:, departure:, location:)
+          visit_search_results_page(saved_destination.departure)
+          expect(page).not_to have_content nearby_result[:variable][:name]
+          find('.fa.fa-commenting.text-2xl').click
+          expect(page).not_to have_content published_comment_destination.name
+          find('.fa.fa-folder-open.text-2xl').click
+          expect(page).to have_content saved_destination.name
         end
       end
 
-      context '各項目20件以上の目的地が存在する状態で検索結果ページにアクセスする' do
-        it '20件ずつ表示される' do
-        end
-      end
+      # context '各項目20件以上の目的地が存在する状態で検索結果ページにアクセスする' do
     end
   end
 end

--- a/spec/system/search/results_spec.rb
+++ b/spec/system/search/results_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe "Search::Results", type: :system do
           expect(page).to have_content published_comment_destination.comment
           expect(page).to have_css '.fa.fa-eye'
           expect(page).not_to have_css '.fa.fa-eye-slash'
-          expect(page).to have_css '.fa.fa-commenting'
+          expect(find('#center-content')).to have_css '.fa.fa-commenting'
         end
 
         it 'リンク関連が正しく表示されている' do
@@ -81,7 +81,7 @@ RSpec.describe "Search::Results", type: :system do
           expect(page).to have_content another_published_comment_destination.comment
           expect(page).to have_css '.fa.fa-eye'
           expect(page).not_to have_css '.fa.fa-eye-slash'
-          expect(page).to have_css '.fa.fa-commenting'
+          expect(find('#center-content')).to have_css '.fa.fa-commenting'
         end
       end
 
@@ -93,6 +93,114 @@ RSpec.describe "Search::Results", type: :system do
           visit_search_results_page(departure)
           find('.fa.fa-commenting.text-2xl').click
           expect(page).not_to have_content another_not_published_comment_destination.name
+        end
+      end
+    end
+  end
+
+  describe 'Saved' do
+    context 'Contents' do
+      let(:destination) { create(:destination, is_saved: true, user:, departure:) }
+      let(:published_comment_destination) { create(:destination, :published_comment, departure:, user:) }
+      let(:not_published_comment_destination) { create(:destination, :not_published_comment, departure:, user:) }
+
+      before { nearby_mock(nearby_result) }
+
+      context '検索結果ページにアクセスする' do
+        context '保存済みコメントをしていない目的地が存在する' do
+          it 'コメントと関連するアイコンが表示されない' do
+            visit_search_results_page(destination.departure)
+            find('.fa.fa-folder-open.text-2xl').click
+            expect(page).to have_content I18n.l(destination.created_at, format: :short)
+            expect(page).to have_content destination.name
+            expect(page).to have_content destination.address
+            expect(page).not_to have_css '.fa.fa-eye'
+            expect(page).not_to have_css '.fa.fa-eye-slash'
+            expect(find('#right-content')).not_to have_css '.fa.fa-commenting'
+          end
+        end
+
+        context '自身の保存済み公開コメントの目的地が存在する' do
+          it 'コメント・コメントアイコン・公開アイコンが表示される' do
+            visit_search_results_page(published_comment_destination.departure)
+            find('.fa.fa-folder-open.text-2xl').click
+            expect(page).to have_content I18n.l(published_comment_destination.created_at, format: :short)
+            expect(page).to have_content published_comment_destination.name
+            expect(page).to have_content published_comment_destination.address
+            expect(page).to have_content published_comment_destination.comment
+            expect(page).to have_css '.fa.fa-eye'
+            expect(page).not_to have_css '.fa.fa-eye-slash'
+            expect(find('#right-content')).to have_css '.fa.fa-commenting'
+          end
+        end
+
+        context '自身の保存済み非公開コメントの目的地が存在する' do
+          it 'コメント・コメントアイコン・非公開アイコンが表示される' do
+            visit_search_results_page(not_published_comment_destination.departure)
+            find('.fa.fa-folder-open.text-2xl').click
+            expect(page).to have_content I18n.l(not_published_comment_destination.created_at, format: :short)
+            expect(page).to have_content not_published_comment_destination.name
+            expect(page).to have_content not_published_comment_destination.address
+            expect(page).to have_content not_published_comment_destination.comment
+            expect(page).not_to have_css '.fa.fa-eye'
+            expect(page).to have_css '.fa.fa-eye-slash'
+            expect(find('#right-content')).to have_css '.fa.fa-commenting'
+          end
+        end
+
+        it 'リンク関連が正しく表示されている' do
+          visit_search_results_page(destination.departure)
+          find('.fa.fa-folder-open.text-2xl').click
+          expect(page).to have_link '決定', href: new_history_path(destination: destination.uuid)
+        end
+      end
+
+      context '他ユーザーの保存済み目的地が存在する状態で検索結果ページにアクセスする' do
+        it '該当目的地が表示されない' do
+          # saved_own = destination
+          # saved_other = create(:destination, user: other, is_saved: true)
+          # visit_saved_destinations_page(saved_own)
+          # expect(page).to have_content saved_own.name
+          # expect(page).not_to have_content saved_other.name
+        end
+      end
+
+      context '保存済み・未保存目的地が存在する状態で検索結果ページにアクセスする' do
+        it '保存済み目的地のみ表示される' do
+          # saved_destination = destination
+          # not_saved_destination = create(:destination, user:, is_saved: false)
+          # visit_saved_destinations_page(saved_destination)
+          # expect(page).to have_content saved_destination.name
+          # expect(page).not_to have_content not_saved_destination.name
+        end
+      end
+    end
+  end
+
+  describe 'Other' do
+    context 'Contents' do
+      context '検索結果と公開コメントで重複した目的地がある' do
+        it 'コメントの枠で表示されている' do
+        end
+      end
+
+      context '公開コメントと保存済みで重複した目的地がある' do
+        it '保存済みの枠で表示されている' do
+        end
+      end
+
+      context '検索結果と保存済みで重複した目的地がある' do
+        it '保存済みの枠で表示されている' do
+        end
+      end
+
+      context '検索結果と公開コメントと保存済みで重複した目的地がある' do
+        it '保存済みの枠で表示されている' do
+        end
+      end
+
+      context '各項目20件以上の目的地が存在する状態で検索結果ページにアクセスする' do
+        it '20件ずつ表示される' do
         end
       end
     end

--- a/spec/system/search/select_departures_spec.rb
+++ b/spec/system/search/select_departures_spec.rb
@@ -7,22 +7,6 @@ RSpec.describe "Search::SelectDepartures", type: :system do
   let(:user) { create(:user) }
   let(:other) { create(:user) }
 
-    def visit_new_departure_page(departure)
-      login(departure.user)
-      sleep(0.1)
-      visit new_departure_path
-    end
-
-    def visit_select_saved_departures_page(departure)
-      visit_new_departure_page(departure)
-      find('.fa.fa-folder-open.text-2xl').click
-    end
-
-    def visit_select_history_departure_page(departure)
-      visit_new_departure_page(departure)
-      find('.fa.fa-history.text-2xl').click
-    end
-
   describe 'Page' do
     context '出発地を入力するページにアクセスする' do
       it '情報が正しく表示されている' do

--- a/spec/system/search/select_departures_spec.rb
+++ b/spec/system/search/select_departures_spec.rb
@@ -57,7 +57,9 @@ RSpec.describe "Search::SelectDepartures", type: :system do
           expect(page).to have_link '削除', href: departure_path(departure.uuid)
           click_link '編集'
           expect(page).to have_link '取消', href: departure_path(departure.uuid)
+          expect(page).to have_button '更新'
           expect(find('form')['action']).to be_include departure_path(departure.uuid)
+          expect(find('input[name="_method"]', visible: false)['value']).to eq 'patch'
         end
       end
 

--- a/spec/system/search/select_departures_spec.rb
+++ b/spec/system/search/select_departures_spec.rb
@@ -1,8 +1,9 @@
 require 'rails_helper'
 
 RSpec.describe "Search::SelectDepartures", type: :system do
-  let(:departure) { create(:departure, is_saved: true) }
-  let(:history) { create(:history) }
+  let(:departure) { create(:departure, is_saved: true, user:) }
+  let(:destination) { create(:destination, departure:, user:) }
+  let(:history) { create(:history, destination:, user:) }
   let(:user) { create(:user) }
   let(:other) { create(:user) }
 
@@ -83,6 +84,65 @@ RSpec.describe "Search::SelectDepartures", type: :system do
 
     describe 'Start' do
       before { visit_select_saved_departures_page(departure) }
+
+      context '出発ボタンをクリックする' do
+        it '目的地の条件入力ページに遷移する' do
+          click_link '出発'
+          expect(current_url).to be_include new_search_path(departure: departure.uuid)
+        end
+      end
+    end
+  end
+
+  describe 'History' do
+    describe 'Contents' do
+      context '１つの出発地を保存する' do
+        before { visit_select_history_departure_page(history.departure) }
+
+        it '情報が正しく表示されている' do
+          expect(current_path).to eq new_departure_path
+          expect(page).to have_content history.departure.name
+          expect(page).to have_content history.departure.address
+          expect(page).to have_content I18n.l(history.start_time, format: :short)
+          expect(page).to have_content "#{history.decorate.moving_time}分"
+          expect(page).to have_content "#{history.moving_distance}m"
+          expect(page).to have_content history.destination.name
+        end
+
+        it 'リンク関連が正しく表示されている' do
+          expect(page).to have_link '出発', href: new_search_path(departure: history.departure.uuid)
+        end
+      end
+
+      context '複数のユーザーの履歴を作成する' do
+        it '自分の履歴のみ表示される' do
+          own_history = history
+          other_history = create(:history, user: other)
+          visit_select_history_departure_page(own_history)
+          expect(page).to have_content own_history.departure.name
+          expect(page).to have_content own_history.destination.name
+          expect(page).not_to have_content other_history.departure.name
+          expect(page).not_to have_content other_history.destination.name
+        end
+      end
+
+      context '保存済み・未保存出発地を作成する' do
+        it 'どちらも表示される' do
+          saved_departure_history = history
+          not_saved_departure = create(:departure, is_saved: false, user:)
+          not_saved_destination = create(:destination, user:, departure: not_saved_departure)
+          not_saved_departure_history = create(:history, user:, destination: not_saved_destination)
+          visit_select_history_departure_page(saved_departure_history.departure)
+          expect(page).to have_content saved_departure_history.departure.name
+          expect(page).to have_content saved_departure_history.destination.name
+          expect(page).to have_content not_saved_departure_history.departure.name
+          expect(page).to have_content not_saved_departure_history.destination.name
+        end
+      end
+    end
+
+    describe 'Start' do
+      before { visit_select_history_departure_page(history.departure) }
 
       context '出発ボタンをクリックする' do
         it '目的地の条件入力ページに遷移する' do

--- a/spec/system/search/select_departures_spec.rb
+++ b/spec/system/search/select_departures_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+RSpec.describe "Search::SelectDepartures", type: :system do
+  let(:departure) { create(:departure, is_saved: true) }
+  let(:history) { create(:history) }
+  let(:user) { create(:user) }
+  let(:other) { create(:user) }
+
+    def visit_new_departure_page(departure)
+      login(departure.user)
+      sleep(0.1)
+      visit new_departure_path
+    end
+
+    def visit_select_saved_departures_page(departure)
+      visit_new_departure_page(departure)
+      find('.fa.fa-folder-open.text-2xl').click
+    end
+
+    def visit_select_history_departure_page(departure)
+      visit_new_departure_page(departure)
+      find('.fa.fa-history.text-2xl').click
+    end
+
+  describe 'Page' do
+    context '出発地を入力するページにアクセスする' do
+      it '情報が正しく表示されている' do
+        login(user)
+        sleep(0.1)
+        find('.fa.fa-search.nav-icon').click
+        expect(current_path).to eq new_departure_path
+        expect(page).to have_content '出発地'
+        expect(page).to have_content '入力'
+        expect(page).to have_content '保存'
+        expect(page).to have_content '履歴'
+      end
+    end
+  end
+
+  describe 'Saved' do
+    describe 'Contents' do
+      context '１つの出発地を保存する' do
+        before { visit_select_saved_departures_page(departure) }
+
+        it '情報が正しく表示されている' do
+          expect(current_path).to eq new_departure_path
+          expect(page).to have_content departure.name
+          expect(page).to have_content departure.address
+          expect(page).to have_content I18n.l(departure.created_at, format: :short)
+        end
+
+        it 'リンク関連が正しく表示されている' do
+          expect(page).to have_link '出発', href: new_search_path(departure: departure.uuid)
+          find('.fa.fa-chevron-down').click
+          expect(page).to have_link '編集', href: edit_departure_path(departure.uuid)
+          expect(page).to have_link '削除', href: departure_path(departure.uuid)
+          click_link '編集'
+          expect(page).to have_link '取消', href: departure_path(departure.uuid)
+          expect(find('form')['action']).to be_include departure_path(departure.uuid)
+        end
+      end
+
+      context '複数のユーザーの保存済み出発地を作成する' do
+        it '自分の保存済み出発地のみ表示される' do
+          saved_own = create(:departure, user:, is_saved: true)
+          saved_other = create(:departure, user: other, is_saved: true)
+          visit_select_saved_departures_page(saved_own)
+          expect(page).to have_content saved_own.name
+          expect(page).not_to have_content saved_other.name
+        end
+      end
+
+      context '保存済み・未保存出発地を作成する' do
+        it '保存済み出発地のみ表示される' do
+          saved_departure = create(:departure, user:, is_saved: true)
+          not_saved_departure = create(:departure, user:, is_saved: false)
+          visit_select_saved_departures_page(saved_departure)
+          expect(page).to have_content saved_departure.name
+          expect(page).not_to have_content not_saved_departure.name
+        end
+      end
+    end
+
+    describe 'Start' do
+      before { visit_select_saved_departures_page(departure) }
+
+      context '出発ボタンをクリックする' do
+        it '目的地の条件入力ページに遷移する' do
+          click_link '出発'
+          expect(current_url).to be_include new_search_path(departure: departure.uuid)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- 出発地検索・選択、条件入力、目的地一覧表示のSystemSpecを作成
└ #67
- rubocop-rspecを導入
└ #48 
- クラスによって出し分けする際にはinstance_of?を使用
- 目的地が重複している場合は検索結果<コメント<保存済みの優先度で表示
└ #73 
- SystemSpecでvcrは使用しないように
└ #67
- 表示されているMapのテストは一旦保留するため、読み込まないように
└ #71
- 現在地取得のテストは一旦保留するため、読み込まないように
└ #71
