### PR TITLE
システムスペックを最後まで追加

### DIFF
--- a/app/controllers/destinations_controller.rb
+++ b/app/controllers/destinations_controller.rb
@@ -3,7 +3,7 @@ class DestinationsController < ApplicationController
   before_action :check_candidates_session, only: %i[new create]
   before_action :check_and_set_candidate_from_session, only: %i[new create]
   before_action :set_destination_and_location, only: %i[show edit update destroy]
-  before_action :set_route, only: %i[edit update destroy]
+  before_action :set_route, only: %i[show edit update destroy]
 
   def show
     case @route
@@ -64,8 +64,7 @@ class DestinationsController < ApplicationController
     case @route
     when 'start_page'
       @destination.destroy!
-      flash.now[:success] = '保存済みから削除しました'
-      redirect_to searches_path, status: :see_other
+      redirect_to searches_path, flash: { success: ' 保存済みから削除しました' }, status: :see_other
     when 'saved_page'
       @destination.update!(is_saved: false)
       flash.now[:success] = '目的地を保存済みから削除しました'

--- a/app/controllers/histories_controller.rb
+++ b/app/controllers/histories_controller.rb
@@ -5,6 +5,8 @@ class HistoriesController < ApplicationController
   before_action :set_history, only: %i[show edit update destroy cancel]
   before_action :set_route, only: %i[edit update destroy cancel]
 
+  skip_before_action :check_not_finished, only: %i[show]
+
   def show
     @departure_info = @history.departure.attributes_for_session
     @destination_info = @history.destination.attributes_for_session

--- a/app/forms/guest_form.rb
+++ b/app/forms/guest_form.rb
@@ -6,11 +6,13 @@ class GuestForm
   attribute :address, :string
   attribute :radius, :integer
   attribute :type, :string
+  attribute :is_saved, :boolean, default: false
 
   validates :name, length: { maximum: 50 }
   validates :address, presence: true, length: { maximum: 255 }
   validates :radius, presence: true, numericality:  { only_integer: true, in: 1_000..5_000 }
   validates :type, presence: true, inclusion: { in: Settings.google.place_type.to_h.values }, length: { maximum: 255 }
+  validates :is_saved, inclusion: { in: [true, false] }
 
   def term
     { radius:, type: }

--- a/app/javascript/map/geocode.js
+++ b/app/javascript/map/geocode.js
@@ -21,7 +21,11 @@ window.getCurrentLocation = () => {
     geocoder.geocode({ location: latLng, region: 'JP' })
       .then((response) => {
         if (response.results[0]) {
-          form.value = response.results[0].formatted_address.split(' ').pop();
+          const formatted_address = response.results[0].formatted_address.match(/.*[\d１-９]{3}[-ー−][\d１-９]{4}\s*(.+)/)[1];
+          form.value = formatted_address.replace(/[０-９ａ-ｚＡ-Ｚ．＠−]/g, function (s) {
+            return String.fromCharCode(s.charCodeAt(0) - (s >= "０" && s <= "９" ? 0xFEE0 : 0));
+          }).replace(/(\d)[-ー−]/g, '$1-').replace(/\s/, ' ');
+
           toastr.success('現在地を取得しました');
           loading.classList.toggle('hidden');
         } else {

--- a/app/javascript/map/geocode.js
+++ b/app/javascript/map/geocode.js
@@ -3,7 +3,7 @@ import toastr from "toastr";
 window.getCurrentLocation = () => {
   const button = document.getElementById('js-get-current-location-button');
   const loading = document.getElementById('js-loading-text');
-  const form = document.getElementById('departure_form_address')
+  const form = document.getElementById('departure_form_address') || document.getElementById('guest_form_address');
 
   toastr.options = {
     "closeButton": true,

--- a/app/javascript/map/show-candidates.js
+++ b/app/javascript/map/show-candidates.js
@@ -57,7 +57,7 @@ window.showCandidates = () => {
     return marker
   };
 
-  let infoWindow; // info windowは出発地を覗いて1つしか開かないようにするための変数
+  let infoWindow; // info windowは出発地を除いて1つしか開かないようにするための変数
   const openInfoWindow = (location, marker) => { // マーカーにinfo windowをつける関数
     if (infoWindow) {
       infoWindow.close();

--- a/app/services/pick_candidates_service.rb
+++ b/app/services/pick_candidates_service.rb
@@ -8,8 +8,8 @@ class PickCandidatesService
   def call
     nearby_destinations = search_nearby_destinations
 
-    nearby_commented_info = acquisition_commented_info(nearby_destinations).sample(20)
-    nearby_own_info = acquisition_own_info(nearby_destinations).sample(20)
+    nearby_commented_info = acquisition_commented_info(nearby_destinations)
+    nearby_own_info = acquisition_own_info(nearby_destinations)
 
     pick_candidates = { results:, nearby_commented_info:, nearby_own_info: }
     prepare_pick_candidates(pick_candidates)

--- a/app/views/destinations/new.html.erb
+++ b/app/views/destinations/new.html.erb
@@ -10,4 +10,8 @@
 <% end %>
 
 <%= include_gon %>
-<%= javascript_include_tag Settings.google.map_url + 'callback=showRoute', defer: 'defer' %>
+
+<% # 表示されているMapのテストは一旦保留するため、読み込まない %>
+<% unless Rails.env.test? %>
+  <%= javascript_include_tag Settings.google.map_url + 'callback=showRoute', defer: 'defer' %>
+<% end %>

--- a/app/views/guests/_form.html.erb
+++ b/app/views/guests/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_with model: guest_form, url: guests_path, method: :get, class: 'zen-kaku-medium' do |f| %>
   <div class="my-5">
     <%= f.label :address %>
-    <%= f.text_field :address, class: 'normal-form', id: 'js-address-form' %>
+    <%= f.text_field :address, class: 'normal-form' %>
     <%= link_to '現在地取得', '#', class: 'text-blue-600 underline', id: 'js-get-current-location-button' %>
     <p class="hidden" id="js-loading-text">読込中……</p>
     <%= render partial: 'shared/error_message', collection: guest_form.errors.full_messages_for(:address) %>
@@ -20,6 +20,6 @@
   </div>
 
   <div class="my-5 text-right">
-    <%= f.submit '決定', class: 'orange-btn tracking-wider text-xl px-5 py-2.5 zen-kaku-regular' %>
+    <%= f.submit '検索', class: 'orange-btn tracking-wider text-xl px-5 py-2.5 zen-kaku-regular' %>
   </div>
 <% end %>

--- a/app/views/guests/index.html.erb
+++ b/app/views/guests/index.html.erb
@@ -27,4 +27,8 @@
 </div>
 
 <%= include_gon %>
-<%= javascript_include_tag Settings.google.map_url + 'callback=showCandidates', defer: 'defer' %>
+
+<% # 表示されているMapのテストは一旦保留するため、読み込まない %>
+<% unless Rails.env.test? %>
+  <%= javascript_include_tag Settings.google.map_url + 'callback=showCandidates', defer: 'defer' %>
+<% end %>

--- a/app/views/guests/new.html.erb
+++ b/app/views/guests/new.html.erb
@@ -4,4 +4,7 @@
   <%= render 'form', guest_form: @guest_form %>
 </div>
 
-<%= javascript_include_tag Settings.google.map_url + 'callback=getCurrentLocation', defer: 'defer' %>
+<% # 現在地取得のテストは一旦保留するため、読み込まない %>
+<% unless Rails.env.test? %>
+  <%= javascript_include_tag Settings.google.map_url + 'callback=getCurrentLocation', defer: 'defer' %>
+<% end %>

--- a/app/views/histories/_history.html.erb
+++ b/app/views/histories/_history.html.erb
@@ -41,7 +41,7 @@
           class: 'border-orange-btn tracking-widest text-lg px-8 py-1.5 zen-kaku-regular mr-4' %>
 
           <%= link_to '削除', history_path(history.uuid, route: 'goal_page'),
-          data: { turbo_frame: '_top', turbo_method: :delete, turbo_confirm: "保存済みから削除します\nよろしいですか?"},
+          data: { turbo_frame: '_top', turbo_method: :delete, turbo_confirm: "履歴から削除します\nよろしいですか?"},
           class: 'border-orange-btn tracking-widest text-lg px-8 py-1.5 zen-kaku-regular border-red-600 text-red-600' %>
         </div>
       </div>

--- a/app/views/histories/new.html.erb
+++ b/app/views/histories/new.html.erb
@@ -11,4 +11,8 @@
 <% end %>
 
 <%= include_gon %>
-<%= javascript_include_tag Settings.google.map_url + 'callback=showRoute', defer: 'defer' %>
+
+<% # 表示されているMapのテストは一旦保留するため、読み込まない %>
+<% unless Rails.env.test? %>
+  <%= javascript_include_tag Settings.google.map_url + 'callback=showRoute', defer: 'defer' %>
+<% end %>

--- a/app/views/histories/show.html.erb
+++ b/app/views/histories/show.html.erb
@@ -10,4 +10,8 @@
 <% end %>
 
 <%= include_gon %>
-<%= javascript_include_tag Settings.google.map_url + 'callback=showRoute', defer: 'defer' %>
+
+<% # 表示されているMapのテストは一旦保留するため、読み込まない %>
+<% unless Rails.env.test? %>
+  <%= javascript_include_tag Settings.google.map_url + 'callback=showRoute', defer: 'defer' %>
+<% end %>

--- a/spec/factories/destinations.rb
+++ b/spec/factories/destinations.rb
@@ -5,6 +5,11 @@ FactoryBot.define do
     association :location, :for_destination
     association :departure
 
+    trait :commented do
+      is_saved { true }
+      sequence(:comment, 'destination-comment-1')
+    end
+
     trait :published_comment do
       is_saved { true }
       sequence(:comment, 'destination-comment-1')

--- a/spec/factories/forms/destination_forms.rb
+++ b/spec/factories/forms/destination_forms.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :destination_form do
     name { 'destination-form-name' }
     comment { 'destination-form-comment' }
-    distance { 1000 }
+    distance { 1500 }
     is_saved { false }
     is_published_comment { false }
   end

--- a/spec/factories/forms/guest_forms.rb
+++ b/spec/factories/forms/guest_forms.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :guest_form do
     name { 'guest-form-name' }
     address { '東京都港区芝公園4丁目2-8' }
-    radius { '1000' }
+    radius { '5000' }
     type { 'convenience_store' }
   end
 end

--- a/spec/factories/histories.rb
+++ b/spec/factories/histories.rb
@@ -10,6 +10,10 @@ FactoryBot.define do
       sequence(:comment, 'history-comment-1')
     end
 
+    trait :not_finished do
+      end_time { nil }
+    end
+
     trait :another do
       moving_distance { rand(2001..10_000) }
       start_time { Time.zone.now.ago(3.hours) }

--- a/spec/models/destination_spec.rb
+++ b/spec/models/destination_spec.rb
@@ -139,6 +139,46 @@ RSpec.describe Destination do
           expect(destination.errors).to be_empty
         end
       end
+
+      context 'コメントを入力、公開する、保存しない' do
+        it 'コメントが空白、非公開になる' do
+          destination = build(:destination, comment: 'a', is_published_comment: true, is_saved: false)
+          expect(destination.save).to be_truthy
+          expect(destination.comment).to be_nil
+          expect(destination.is_published_comment).to be_falsey
+          expect(destination.is_saved).to be_falsey
+        end
+      end
+
+      context 'コメントを入力、公開する、保存する' do
+        it 'コメントが空白、非公開になる' do
+          destination = build(:destination, comment: 'a', is_published_comment: true, is_saved: true)
+          expect(destination.save).to be_truthy
+          expect(destination.comment).to eq 'a'
+          expect(destination.is_published_comment).to be_truthy
+          expect(destination.is_saved).to be_truthy
+        end
+      end
+
+      context 'コメントを空白、非公開、保存しない' do
+        it 'コメントが空白、非公開のままになる' do
+          destination = build(:destination, comment: '', is_published_comment: false, is_saved: false)
+          expect(destination.save).to be_truthy
+          expect(destination.comment).to be_nil
+          expect(destination.is_published_comment).to be_falsey
+          expect(destination.is_saved).to be_falsey
+        end
+      end
+
+      context 'コメントを空白、非公開、保存する' do
+        it 'コメントが空白、非公開のままになる' do
+          destination = build(:destination, comment: '', is_published_comment: false, is_saved: true)
+          expect(destination.save).to be_truthy
+          expect(destination.comment).to be_nil
+          expect(destination.is_published_comment).to be_falsey
+          expect(destination.is_saved).to be_truthy
+        end
+      end
     end
 
     describe '#is_published_comment' do
@@ -183,6 +223,42 @@ RSpec.describe Destination do
           expect(destination.is_published_comment).to be_truthy
           expect(destination).to be_valid
           expect(destination.errors).to be_empty
+        end
+      end
+
+      context 'コメントを入力せず、公開する' do
+        it '保存した際に非公開になる' do
+          destination = build(:destination, comment: '', is_published_comment: true, is_saved: true)
+          expect(destination.save).to be_truthy
+          expect(destination.comment).to be_nil
+          expect(destination.is_published_comment).to be_falsey
+        end
+      end
+
+      context 'コメントを入力して、公開する' do
+        it '保存した際にそのまま公開になる' do
+          destination = build(:destination, comment: 'a', is_published_comment: true, is_saved: true)
+          expect(destination.save).to be_truthy
+          expect(destination.comment).to eq 'a'
+          expect(destination.is_published_comment).to be_truthy
+        end
+      end
+
+      context 'コメントを入力せずに、非公開する' do
+        it '保存した際にそのまま非公開になる' do
+          destination = build(:destination, comment: '', is_published_comment: false, is_saved: true)
+          expect(destination.save).to be_truthy
+          expect(destination.comment).to be_nil
+          expect(destination.is_published_comment).to be_falsey
+        end
+      end
+
+      context 'コメントを入力して、非公開する' do
+        it '保存した際にそのまま非公開になる' do
+          destination = build(:destination, comment: 'a', is_published_comment: false, is_saved: true)
+          expect(destination.save).to be_truthy
+          expect(destination.comment).to eq 'a'
+          expect(destination.is_published_comment).to be_falsey
         end
       end
     end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,6 +63,9 @@ RSpec.configure do |config|
 
   config.include FactoryBot::Syntax::Methods
   config.include LoginMacros
-  config.include VisitMacros
   config.include MockMacros
+  config.include GuestMacros
+  config.include ProfileMacros
+  config.include SavedPlaceMacros
+  config.include SearchMacros
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -68,4 +68,5 @@ RSpec.configure do |config|
   config.include ProfileMacros
   config.include SavedPlaceMacros
   config.include SearchMacros
+  config.include LayoutMacros
 end

--- a/spec/support/guest_macros.rb
+++ b/spec/support/guest_macros.rb
@@ -1,0 +1,12 @@
+module GuestMacros
+  def visit_results_for_guest_page
+    for_departure = build(:location, :for_departure)
+    geocode_mock(for_departure.attributes.compact.symbolize_keys)
+    nearby_mock(Settings.nearby_result.radius_1000.to_hash)
+    visit new_guest_path
+    fill_in '出発地の住所', with: for_departure.address
+    fill_in '距離(1000m~5000m)', with: 5000
+    select 'コンビニエンスストア', from: '目的地の種類'
+    click_button '検索'
+  end
+end

--- a/spec/support/layout_macros.rb
+++ b/spec/support/layout_macros.rb
@@ -1,0 +1,10 @@
+module LayoutMacros
+  def verify_guest_layout
+    expect(page).to have_link "Today's Course", href: top_path
+    expect(page).to have_link '新規登録', href: signup_path
+    expect(page).to have_link 'ログイン', href: login_path
+  end
+
+  def verify_user_layout
+  end
+end

--- a/spec/support/layout_macros.rb
+++ b/spec/support/layout_macros.rb
@@ -1,18 +1,16 @@
 module LayoutMacros
-  def verify_guest_layout
-    expect(page).to have_link "Today's Course", href: top_path
-    expect(page).to have_link '新規登録', href: signup_path
-    expect(page).to have_link 'ログイン', href: login_path
+  def nav_search_icon
+    a_tag = find('.fa.fa-search.nav-icon').find(:xpath, '..')
+    URI.parse(a_tag[:href]).path
   end
 
-  def verify_user_layout
-    nav_search_icon = find('.fa.fa-search.nav-icon').find(:xpath, '..')
-    expect(URI.parse(nav_search_icon[:href]).path).to eq new_departure_path
+  def nav_folder_icon
+    a_tag = find('.fa.fa-folder-open.nav-icon').find(:xpath, '..')
+    URI.parse(a_tag[:href]).path
+  end
 
-    nav_folder_icon = find('.fa.fa-folder-open.nav-icon').find(:xpath, '..')
-    expect(URI.parse(nav_folder_icon[:href]).path).to eq departures_path
-
-    nav_user_icon = find('.fa.fa-user.nav-icon').find(:xpath, '..')
-    expect(URI.parse(nav_user_icon[:href]).path).to eq profile_path
+  def nav_user_icon
+    a_tag = find('.fa.fa-user.nav-icon').find(:xpath, '..')
+    URI.parse(a_tag[:href]).path
   end
 end

--- a/spec/support/layout_macros.rb
+++ b/spec/support/layout_macros.rb
@@ -6,5 +6,13 @@ module LayoutMacros
   end
 
   def verify_user_layout
+    nav_search_icon = find('.fa.fa-search.nav-icon').find(:xpath, '..')
+    expect(URI.parse(nav_search_icon[:href]).path).to eq new_departure_path
+
+    nav_folder_icon = find('.fa.fa-folder-open.nav-icon').find(:xpath, '..')
+    expect(URI.parse(nav_folder_icon[:href]).path).to eq departures_path
+
+    nav_user_icon = find('.fa.fa-user.nav-icon').find(:xpath, '..')
+    expect(URI.parse(nav_user_icon[:href]).path).to eq profile_path
   end
 end

--- a/spec/support/profile_macros.rb
+++ b/spec/support/profile_macros.rb
@@ -1,0 +1,11 @@
+module ProfileMacros
+  def visit_histories_page(history)
+    login(history.user)
+    sleep(0.1)
+  end
+
+  def visit_setting_page(user)
+    login(user)
+    find('label[for=right]').click
+  end
+end

--- a/spec/support/saved_place_macros.rb
+++ b/spec/support/saved_place_macros.rb
@@ -1,0 +1,22 @@
+module SavedPlaceMacros
+  def visit_saved_departures_page(departure)
+    login(departure.user)
+    sleep(0.1)
+    visit departures_path
+    sleep(0.1)
+    find('label[for=left]').click
+  end
+
+  def visit_edit_departure_page(departure)
+    visit_saved_departures_page(departure)
+    find('.fa.fa-chevron-down').click
+    click_link('編集')
+    sleep(0.1)
+  end
+
+  def visit_saved_destinations_page(destination)
+    login(destination.user)
+    sleep(0.1)
+    visit departures_path
+  end
+end

--- a/spec/support/saved_place_macros.rb
+++ b/spec/support/saved_place_macros.rb
@@ -19,4 +19,11 @@ module SavedPlaceMacros
     sleep(0.1)
     visit departures_path
   end
+
+  def visit_edit_destination_page(destination)
+    visit_saved_destinations_page(destination)
+    find('.fa.fa-chevron-down').click
+    click_link('編集')
+    sleep(0.1)
+  end
 end

--- a/spec/support/search_macros.rb
+++ b/spec/support/search_macros.rb
@@ -1,30 +1,4 @@
-module VisitMacros
-  def visit_saved_departures_page(departure)
-    login(departure.user)
-    sleep(0.1)
-    visit departures_path
-    sleep(0.1)
-    find('label[for=left]').click
-  end
-
-  def visit_edit_departure_page(departure)
-    visit_saved_departures_page(departure)
-    find('.fa.fa-chevron-down').click
-    click_link('編集')
-    sleep(0.1)
-  end
-
-  def visit_saved_destinations_page(destination)
-    login(destination.user)
-    sleep(0.1)
-    visit departures_path
-  end
-
-  def visit_histories_page(history)
-    login(history.user)
-    sleep(0.1)
-  end
-
+module SearchMacros
   def visit_new_departure_page(user)
     login(user)
     sleep(0.1)
@@ -101,16 +75,5 @@ module VisitMacros
     login(history.user)
     sleep(0.1)
     visit history_path(history.uuid)
-  end
-
-  def visit_results_for_guest_page
-    for_departure = build(:location, :for_departure)
-    geocode_mock(for_departure.attributes.compact.symbolize_keys)
-    nearby_mock(Settings.nearby_result.radius_1000.to_hash)
-    visit new_guest_path
-    fill_in '出発地の住所', with: for_departure.address
-    fill_in '距離(1000m~5000m)', with: 5000
-    select 'コンビニエンスストア', from: '目的地の種類'
-    click_button '検索'
   end
 end

--- a/spec/support/visit_macros.rb
+++ b/spec/support/visit_macros.rb
@@ -22,7 +22,7 @@ module VisitMacros
 
   def visit_histories_page(history)
     login(history.user)
-    sleep(0.2)
+    sleep(0.1)
   end
 
   def visit_new_departure_page(user)
@@ -73,7 +73,13 @@ module VisitMacros
 
   def visit_goal_page_from_not_finished(history)
     login(history.user)
-    sleep(0.2)
+    sleep(0.1)
     click_link 'こちら'
+  end
+
+  def visit_show_history_page(history)
+    login(history.user)
+    sleep(0.1)
+    visit history_path(history.uuid)
   end
 end

--- a/spec/support/visit_macros.rb
+++ b/spec/support/visit_macros.rb
@@ -102,4 +102,15 @@ module VisitMacros
     sleep(0.1)
     visit history_path(history.uuid)
   end
+
+  def visit_results_for_guest_page
+    for_departure = build(:location, :for_departure)
+    geocode_mock(for_departure.attributes.compact.symbolize_keys)
+    nearby_mock(Settings.nearby_result.radius_1000.to_hash)
+    visit new_guest_path
+    fill_in '出発地の住所', with: for_departure.address
+    fill_in '距離(1000m~5000m)', with: 5000
+    select 'コンビニエンスストア', from: '目的地の種類'
+    click_button '検索'
+  end
 end

--- a/spec/support/visit_macros.rb
+++ b/spec/support/visit_macros.rb
@@ -51,7 +51,6 @@ module VisitMacros
     visit_input_terms_page(departure)
     fill_in '距離(1000m~5000m)', with: 5000
     click_button '検索'
-    sleep(0.1)
   end
 
   def visit_new_destination_page(departure)
@@ -59,16 +58,37 @@ module VisitMacros
     click_link '決定'
   end
 
+  def visit_new_destination_page_from_new_departure(user)
+    visit_new_departure_page(user)
+    geocode_mock(build(:location, :for_departure).attributes.compact.symbolize_keys)
+    nearby_mock(Settings.nearby_result.radius_1000.to_hash)
+    fill_in '名称', with: 'departure-name'
+    fill_in '住所', with: 'departure-address'
+    uncheck '保存する'
+    click_button '決定'
+    fill_in '距離(1000m~5000m)', with: 5000
+    click_button '検索'
+    click_link '決定'
+  end
+
   def visit_start_page_from_new(departure)
     visit_new_destination_page(departure)
     fill_in '名称', with: 'destination-name'
-    fill_in '片道の距離', with: 1000
+    fill_in '片道の距離', with: 5000
     click_button '決定'
   end
 
   def visit_start_page_from_saved(destination)
     visit_saved_destinations_page(destination)
     click_link '出発'
+  end
+
+  def visit_start_page_from_not_saved(user)
+    visit_new_destination_page_from_new_departure(user)
+    fill_in '名称', with: 'destination-name'
+    fill_in '片道の距離', with: 5000
+    uncheck '保存する'
+    click_button '決定'
   end
 
   def visit_goal_page_from_not_finished(history)

--- a/spec/support/visit_macros.rb
+++ b/spec/support/visit_macros.rb
@@ -53,4 +53,9 @@ module VisitMacros
     click_button '検索'
     sleep(0.1)
   end
+
+  def visit_new_destination_page(departure)
+    visit_search_results_page(departure)
+    click_link '決定'
+  end
 end

--- a/spec/support/visit_macros.rb
+++ b/spec/support/visit_macros.rb
@@ -49,7 +49,7 @@ module VisitMacros
 
   def visit_search_results_page(departure)
     visit_input_terms_page(departure)
-    fill_in '距離(1000m~5000m)', with: '5000'
+    fill_in '距離(1000m~5000m)', with: 5000
     click_button '検索'
     sleep(0.1)
   end
@@ -57,5 +57,17 @@ module VisitMacros
   def visit_new_destination_page(departure)
     visit_search_results_page(departure)
     click_link '決定'
+  end
+
+  def visit_start_page_from_new(departure)
+    visit_new_destination_page(departure)
+    fill_in '名称', with: 'destination-name'
+    fill_in '片道の距離', with: 1000
+    click_button '決定'
+  end
+
+  def visit_start_page_from_saved(destination)
+    visit_saved_destinations_page(destination)
+    click_link '出発'
   end
 end

--- a/spec/support/visit_macros.rb
+++ b/spec/support/visit_macros.rb
@@ -70,4 +70,10 @@ module VisitMacros
     visit_saved_destinations_page(destination)
     click_link '出発'
   end
+
+  def visit_goal_page_from_not_finished(history)
+    login(history.user)
+    sleep(0.2)
+    click_link 'こちら'
+  end
 end

--- a/spec/system/guest/input_terms_spec.rb
+++ b/spec/system/guest/input_terms_spec.rb
@@ -1,6 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe 'Guest::InputTerms' do
+  let(:guest_form) { build(:guest_form) }
+  let(:for_geocode_result) { build(:location, :for_departure) }
+  let(:geocode_result) { for_geocode_result.attributes.compact.symbolize_keys }
+  let(:nearby_result) { Settings.nearby_result.radius_1000.to_hash }
+  let(:guests_path_and_query) do
+    query = { guest_form: { address: guest_form.address, radius: guest_form.radius, type: guest_form.type } }
+    "#{guests_path}?#{query.to_query}&#{{ commit: '検索' }.to_query}"
+  end
+
   before { visit new_guest_path }
 
   describe 'Page' do
@@ -22,4 +31,203 @@ RSpec.describe 'Guest::InputTerms' do
       end
     end
   end
+
+  describe 'Validations' do
+    context '正常な値を入力する' do
+      let(:guest_form) { build(:guest_form, type: 'cafe') }
+
+      it '目的地の検索に成功し、検索結果ページに遷移する' do
+        geocode_mock(geocode_result)
+        nearby_mock(nearby_result)
+        fill_in '出発地の住所', with: guest_form.address
+        fill_in '距離', with: guest_form.radius
+        select 'カフェ', from: '種類'
+        click_button '検索'
+        expect(page).to have_current_path guests_path_and_query
+        expect(page).to have_content nearby_result[:variable][:name]
+        expect(page).to have_content nearby_result[:fixed][:address]
+      end
+    end
+
+    describe '#address' do
+      before { fill_in '距離', with: guest_form.radius }
+
+      context '住所を空白にする' do
+        it '出発地の取得に失敗し、ゲスト向け検索条件入力ページに戻る' do
+          fill_in '出発地の住所', with: ''
+          click_button '検索'
+          expect(page).to have_current_path new_guest_path
+          expect(page).to have_content '住所を入力してください'
+          expect(page).to have_content '入力情報に誤りがあります'
+        end
+      end
+
+      context '住所を255文字入力する' do
+        let(:guest_form) { build(:guest_form, address: 'a' * 255) }
+
+        it '出発地の取得に成功し、検索結果ページに遷移する' do
+          # 実際に存在する255文字の住所を打ち込んだという仮定
+          geocode_mock(geocode_result)
+          nearby_mock(nearby_result)
+          fill_in '出発地の住所', with: 'a' * 255
+          click_button '検索'
+          sleep(0.1)
+          expect(page).to have_current_path guests_path_and_query
+          expect(page).to have_content nearby_result[:variable][:name]
+          expect(page).to have_content nearby_result[:fixed][:address]
+        end
+      end
+
+      context '住所を256文字入力する' do
+        it '出発地の取得に失敗し、ゲスト向け検索条件入力ページに戻る' do
+          fill_in '出発地の住所', with: 'a' * 256
+          click_button '検索'
+          expect(page).to have_current_path new_guest_path
+          expect(page).to have_content '住所は255文字以内で入力してください'
+          expect(page).to have_content '入力情報に誤りがあります'
+        end
+      end
+    end
+
+    describe '#radius' do
+      before { fill_in '出発地の住所', with: guest_form.address }
+
+      context '距離を空白にする' do
+        it '目的地の検索に失敗し、ゲスト向け検索条件入力ページに戻る' do
+          fill_in '距離(1000m~5000m)', with: ''
+          click_button '検索'
+          expect(page).to have_current_path new_guest_path
+          expect(page).to have_content '入力情報に誤りがあります'
+          expect(page).to have_content '距離を入力してください'
+          expect(page).to have_content '距離は数値で入力してください'
+        end
+      end
+
+      context '距離に999を入力する' do
+        it '目的地の検索に失敗し、ゲスト向け検索条件入力ページに戻る' do
+          fill_in '距離(1000m~5000m)', with: 999
+          click_button '検索'
+          expect(page).to have_current_path new_guest_path
+          # number_fieldで1000~5000に指定
+        end
+      end
+
+      context '距離に1,000を入力する' do
+        let(:guest_form) { build(:guest_form, radius: 1_000) }
+
+        it '目的地の検索に成功し、検索結果ページに遷移する' do
+          geocode_mock(geocode_result)
+          nearby_mock(nearby_result)
+          fill_in '距離(1000m~5000m)', with: 1_000
+          click_button '検索'
+          sleep(0.1)
+          expect(page).to have_current_path guests_path_and_query
+          expect(page).to have_content nearby_result[:variable][:name]
+          expect(page).to have_content nearby_result[:fixed][:address]
+        end
+      end
+
+      context '距離に1,001を入力する' do
+        it '目的地の検索に失敗し、ゲスト向け検索条件入力ページに戻る' do
+          fill_in '距離(1000m~5000m)', with: 1_001
+          click_button '検索'
+          expect(page).to have_current_path new_guest_path
+          # number_fieldでstep: 100に指定
+        end
+      end
+
+      context '距離に5,000を入力する' do
+        let(:guest_form) { build(:guest_form, radius: 5_000) }
+
+        it '目的地の検索に成功し、検索結果ページに遷移する' do
+          geocode_mock(geocode_result)
+          nearby_mock(nearby_result)
+          fill_in '距離(1000m~5000m)', with: 5_000
+          click_button '検索'
+          sleep(0.1)
+          expect(page).to have_current_path guests_path_and_query
+          expect(page).to have_content nearby_result[:variable][:name]
+          expect(page).to have_content nearby_result[:fixed][:address]
+        end
+      end
+
+      context '距離に5,001を入力する' do
+        it '目的地の検索に失敗し、ゲスト向け検索条件入力ページに戻る' do
+          fill_in '距離(1000m~5000m)', with: 5_001
+          click_button '検索'
+          expect(page).to have_current_path new_guest_path
+          # number_fieldで1000~5000に指定
+        end
+      end
+    end
+
+    # describe '#type'
+  end
+
+  describe 'Form' do
+    context '住所を入力し、検索に失敗する' do
+      it 'フォームから入力した住所が消えていない' do
+        address = 'a' * 256
+        fill_in '出発地の住所', with: address
+        click_button '検索'
+        expect(page).to have_field '出発地の住所', with: address
+      end
+    end
+
+    context '距離を入力し、目的地の検索に失敗する' do
+      it 'フォームから入力した距離が消えていない' do
+        # 空白以外はnumber_fieldの設定ではじいているため
+        fill_in '距離(1000m~5000m)', with: 999
+        click_button '検索'
+        expect(page).to have_current_path new_guest_path
+        expect(page).to have_field '距離(1000m~5000m)', with: 999
+      end
+    end
+
+    context '種類を選択し、目的地の検索に失敗する' do
+      it 'フォームから選択した種類が変わっていない' do
+        select 'カフェ', from: '目的地の種類'
+        click_button '検索'
+        expect(page).to have_current_path new_guest_path
+        expect(page).to have_select '目的地の種類', selected: 'カフェ'
+      end
+    end
+  end
+
+  describe 'Failure' do
+    before do
+      fill_in '出発地の住所', with: guest_form.address
+      fill_in '距離', with: guest_form.radius
+      select 'カフェ', from: '目的地の種類'
+    end
+
+    context '入力された住所が存在しないため、取得に失敗する' do
+      it 'エラーメッセージが表示され、ゲスト向け検索条件入力ページに戻る' do
+        geocode_mock(false)
+
+        click_button '検索'
+        expect(page).to have_current_path new_guest_path
+        expect(page).to have_content '位置情報の取得に失敗しました'
+        expect(page).to have_field '出発地の住所', with: guest_form.address
+        expect(page).to have_field '距離(1000m~5000m)', with: guest_form.radius
+        expect(page).to have_select '目的地の種類', selected: 'カフェ'
+      end
+    end
+
+    context '条件に合致する目的地が存在しないため、検索に失敗する' do
+      it 'エラーメッセージが表示され、ゲスト向け検索条件入力ページに戻る' do
+        geocode_mock(geocode_result)
+        nearby_mock(false)
+
+        click_button '検索'
+        expect(page).to have_current_path new_guest_path
+        expect(page).to have_content '目的地が見つかりませんでした'
+        expect(page).to have_field '出発地の住所', with: guest_form.address
+        expect(page).to have_field '距離(1000m~5000m)', with: guest_form.radius
+        expect(page).to have_select '目的地の種類', selected: 'カフェ'
+      end
+    end
+  end
+
+  # describe 'GetCurrentLocation'
 end

--- a/spec/system/guest/input_terms_spec.rb
+++ b/spec/system/guest/input_terms_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'Guest::InputTerms' do
+  before { visit new_guest_path }
+
+  describe 'Page' do
+    context 'ゲスト向け検索条件入力ページにアクセスする' do
+      it '情報が正しく表示されている' do
+        expect(page).to have_link '現在地取得'
+        expect(page).to have_current_path new_guest_path
+      end
+    end
+  end
+
+  describe 'Contents' do
+    context 'ゲスト向け検索条件入力ページにアクセスする' do
+      it 'リンク関連が正しく表示されている' do
+        expect(page).to have_button '検索'
+        expect(find('form')['action']).to be_include guests_path
+        expect(find('form')['method']).to eq 'get'
+        expect(page).not_to have_field('_method', type: 'hidden')
+      end
+    end
+  end
+end

--- a/spec/system/guest/input_terms_spec.rb
+++ b/spec/system/guest/input_terms_spec.rb
@@ -167,20 +167,18 @@ RSpec.describe 'Guest::InputTerms' do
   describe 'Form' do
     context '住所を入力し、検索に失敗する' do
       it 'フォームから入力した住所が消えていない' do
-        address = 'a' * 256
-        fill_in '出発地の住所', with: address
+        fill_in '出発地の住所', with: guest_form.address
         click_button '検索'
-        expect(page).to have_field '出発地の住所', with: address
+        expect(page).to have_field '出発地の住所', with: guest_form.address
       end
     end
 
     context '距離を入力し、目的地の検索に失敗する' do
       it 'フォームから入力した距離が消えていない' do
-        # 空白以外はnumber_fieldの設定ではじいているため
-        fill_in '距離(1000m~5000m)', with: 999
+        fill_in '距離(1000m~5000m)', with: guest_form.radius
         click_button '検索'
         expect(page).to have_current_path new_guest_path
-        expect(page).to have_field '距離(1000m~5000m)', with: 999
+        expect(page).to have_field '距離(1000m~5000m)', with: guest_form.radius
       end
     end
 

--- a/spec/system/guest/input_terms_spec.rb
+++ b/spec/system/guest/input_terms_spec.rb
@@ -23,7 +23,9 @@ RSpec.describe 'Guest::InputTerms' do
       end
 
       it '共通レイアウトが正常に表示されている' do
-        verify_guest_layout
+        expect(page).to have_link "Today's Course", href: top_path
+        expect(page).to have_link '新規登録', href: signup_path
+        expect(page).to have_link 'ログイン', href: login_path
       end
     end
   end

--- a/spec/system/guest/input_terms_spec.rb
+++ b/spec/system/guest/input_terms_spec.rb
@@ -21,6 +21,10 @@ RSpec.describe 'Guest::InputTerms' do
         expect(page).to have_field '距離(1000m~5000m)', with: ''
         expect(page).to have_select '種類', selected: 'コンビニエンスストア'
       end
+
+      it '共通レイアウトが正常に表示されている' do
+        verify_guest_layout
+      end
     end
   end
 

--- a/spec/system/guest/input_terms_spec.rb
+++ b/spec/system/guest/input_terms_spec.rb
@@ -17,6 +17,9 @@ RSpec.describe 'Guest::InputTerms' do
       it '情報が正しく表示されている' do
         expect(page).to have_link '現在地取得'
         expect(page).to have_current_path new_guest_path
+        expect(page).to have_field '出発地の住所', with: ''
+        expect(page).to have_field '距離(1000m~5000m)', with: ''
+        expect(page).to have_select '種類', selected: 'コンビニエンスストア'
       end
     end
   end

--- a/spec/system/guest/login_spec.rb
+++ b/spec/system/guest/login_spec.rb
@@ -3,81 +3,99 @@ require 'rails_helper'
 RSpec.describe 'Guest::Login' do
   let(:user) { create(:user) }
 
-  describe 'ログイン' do
-    before { visit login_path }
+  before { visit login_path }
 
-    describe 'Validations' do
-      context '正常な値を入力する' do
-        it 'ログインが成功し、プロフィールページに遷移する' do
-          fill_in 'メールアドレス', with: user.email
-          fill_in 'パスワード', with: 'user-password'
+  describe 'Page' do
+    context 'ログインページにアクセスする' do
+      it '情報が正しく表示されている' do
+        expect(page).to have_current_path login_path
+        expect(page).to have_content 'ログイン'
+      end
+    end
+  end
+
+  describe 'Contents' do
+    context 'ログインページにアクセスする' do
+      it 'リンク関連が正しく表示されている' do
+        expect(page).to have_button 'ログイン'
+        expect(find('form')['action']).to be_include login_path
+        expect(find('form')['method']).to eq 'post'
+        expect(page).not_to have_field('_method', type: 'hidden')
+      end
+    end
+  end
+
+  describe 'Validations' do
+    context '正常な値を入力する' do
+      it 'ログインが成功し、プロフィールページに遷移する' do
+        fill_in 'メールアドレス', with: user.email
+        fill_in 'パスワード', with: 'user-password'
+        click_button 'ログイン'
+        expect(page).to have_content 'ログインしました'
+        expect(page).to have_current_path profile_path
+      end
+    end
+  end
+
+  describe 'Authentications' do
+    describe '#email' do
+      before { fill_in 'パスワード', with: 'user-password' }
+
+      context 'メールアドレスを入力しない' do
+        it 'ログインが失敗し、ページが遷移しない' do
           click_button 'ログイン'
-          expect(page).to have_content 'ログインしました'
-          expect(page).to have_current_path profile_path
+          expect(page).to have_content 'メールアドレス、もしくはパスワードが間違っています'
+          expect(page).to have_current_path login_path
+        end
+      end
+
+      context '間違ったメールアドレスを入力する' do
+        it 'ログインが失敗し、ページが遷移しない' do
+          fill_in 'メールアドレス', with: 'user-email-wrong@example.com'
+          click_button 'ログイン'
+          expect(page).to have_content 'メールアドレス、もしくはパスワードが間違っています'
+          expect(page).to have_current_path login_path
         end
       end
     end
 
-    describe 'Authentications' do
-      describe '#email' do
-        before { fill_in 'パスワード', with: 'user-password' }
+    describe '#password' do
+      before { fill_in 'メールアドレス', with: user.email }
 
-        context 'メールアドレスを入力しない' do
-          it 'ログインが失敗し、ページが遷移しない' do
-            click_button 'ログイン'
-            expect(page).to have_content 'メールアドレス、もしくはパスワードが間違っています'
-            expect(page).to have_current_path login_path
-          end
-        end
-
-        context '間違ったメールアドレスを入力する' do
-          it 'ログインが失敗し、ページが遷移しない' do
-            fill_in 'メールアドレス', with: 'user-email-wrong@example.com'
-            click_button 'ログイン'
-            expect(page).to have_content 'メールアドレス、もしくはパスワードが間違っています'
-            expect(page).to have_current_path login_path
-          end
+      context 'パスワードを入力しない' do
+        it 'ログインが失敗し、ページが遷移しない' do
+          click_button 'ログイン'
+          expect(page).to have_content 'メールアドレス、もしくはパスワードが間違っています'
+          expect(page).to have_current_path login_path
         end
       end
 
-      describe '#password' do
-        before { fill_in 'メールアドレス', with: user.email }
-
-        context 'パスワードを入力しない' do
-          it 'ログインが失敗し、ページが遷移しない' do
-            click_button 'ログイン'
-            expect(page).to have_content 'メールアドレス、もしくはパスワードが間違っています'
-            expect(page).to have_current_path login_path
-          end
-        end
-
-        context '間違ったパスワードを入力する' do
-          it 'ログインが失敗し、ページが遷移しない' do
-            fill_in 'パスワード', with: 'user-password-wrong'
-            click_button 'ログイン'
-            expect(page).to have_content 'メールアドレス、もしくはパスワードが間違っています'
-            expect(page).to have_current_path login_path
-          end
+      context '間違ったパスワードを入力する' do
+        it 'ログインが失敗し、ページが遷移しない' do
+          fill_in 'パスワード', with: 'user-password-wrong'
+          click_button 'ログイン'
+          expect(page).to have_content 'メールアドレス、もしくはパスワードが間違っています'
+          expect(page).to have_current_path login_path
         end
       end
     end
+  end
 
-    describe 'Form' do
-      context 'メールアドレスを入力し、ログインに失敗する' do
-        it 'フォームから入力したメールアドレスが消えていない' do
-          email = 'user-email@example.com'
-          fill_in 'メールアドレス', with: email
-          click_button 'ログイン'
-          expect(page).to have_field 'メールアドレス', with: email
-        end
+  describe 'Form' do
+    context 'メールアドレスを入力し、ログインに失敗する' do
+      it 'フォームから入力したメールアドレスが消えていない' do
+        email = 'user-email@example.com'
+        fill_in 'メールアドレス', with: email
+        click_button 'ログイン'
+        expect(page).to have_field 'メールアドレス', with: email
       end
+    end
 
-      context 'パスワードを入力し、新規作成に失敗する' do
-        it '入力したパスワードがフォームから消えている' do
-          fill_in 'パスワード', with: 'user-password'
-          click_button 'ログイン'
-          expect(page).to have_field 'パスワード', with: ''
-        end
+    context 'パスワードを入力し、新規作成に失敗する' do
+      it '入力したパスワードがフォームから消えている' do
+        fill_in 'パスワード', with: 'user-password'
+        click_button 'ログイン'
+        expect(page).to have_field 'パスワード', with: ''
       end
     end
   end

--- a/spec/system/guest/login_spec.rb
+++ b/spec/system/guest/login_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Login' do
+RSpec.describe 'Guest::Login' do
   let(:user) { create(:user) }
 
   describe 'ログイン' do

--- a/spec/system/guest/login_spec.rb
+++ b/spec/system/guest/login_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe 'Guest::Login' do
         expect(page).to have_field 'メールアドレス', with: ''
         expect(page).to have_field 'パスワード', with: ''
       end
+
+      it '共通レイアウトが正常に表示されている' do
+        expect(page).to have_link "Today's Course", href: top_path
+        expect(page).to have_link '新規登録', href: signup_path
+        expect(page).not_to have_link 'ログイン', href: login_path
+      end
     end
   end
 

--- a/spec/system/guest/login_spec.rb
+++ b/spec/system/guest/login_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe 'Guest::Login' do
       it '情報が正しく表示されている' do
         expect(page).to have_current_path login_path
         expect(page).to have_content 'ログイン'
+        expect(page).to have_field 'メールアドレス', with: ''
+        expect(page).to have_field 'パスワード', with: ''
       end
     end
   end

--- a/spec/system/guest/results_spec.rb
+++ b/spec/system/guest/results_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe 'Guest::Results' do
       it '情報が正しく表示されている' do
         expect(page).to have_current_path guests_path_and_query
       end
+
+      it '共通レイアウトが正常に表示されている' do
+        verify_guest_layout
+      end
     end
   end
 

--- a/spec/system/guest/results_spec.rb
+++ b/spec/system/guest/results_spec.rb
@@ -17,7 +17,9 @@ RSpec.describe 'Guest::Results' do
       end
 
       it '共通レイアウトが正常に表示されている' do
-        verify_guest_layout
+        expect(page).to have_link "Today's Course", href: top_path
+        expect(page).to have_link '新規登録', href: signup_path
+        expect(page).to have_link 'ログイン', href: login_path
       end
     end
   end

--- a/spec/system/guest/results_spec.rb
+++ b/spec/system/guest/results_spec.rb
@@ -8,9 +8,7 @@ RSpec.describe 'Guest::Results' do
     "#{guests_path}?#{query.to_query}&#{{ commit: '検索' }.to_query}"
   end
 
-  before do
-    visit_results_for_guest_page
-  end
+  before { visit_results_for_guest_page }
 
   describe 'Page' do
     context 'ゲスト向け検索結果ページにアクセスする' do

--- a/spec/system/guest/results_spec.rb
+++ b/spec/system/guest/results_spec.rb
@@ -1,0 +1,35 @@
+require 'rails_helper'
+
+RSpec.describe 'Guest::Results' do
+  let(:nearby_result) { Settings.nearby_result.radius_1000.to_hash }
+  let(:guest_form) { build(:guest_form) }
+  let(:guests_path_and_query) do
+    query = { guest_form: { address: guest_form.address, radius: guest_form.radius, type: guest_form.type } }
+    "#{guests_path}?#{query.to_query}&#{{ commit: '検索' }.to_query}"
+  end
+
+  before do
+    visit_results_for_guest_page
+  end
+
+  describe 'Page' do
+    context 'ゲスト向け検索結果ページにアクセスする' do
+      it '情報が正しく表示されている' do
+        expect(page).to have_current_path guests_path_and_query
+      end
+    end
+  end
+
+  describe 'Contents' do
+    context 'ゲスト向け検索結果ページにアクセスする' do
+      it '情報が正しく表示されている' do
+        expect(page).to have_content nearby_result[:variable][:name]
+        expect(page).to have_content nearby_result[:fixed][:address]
+      end
+
+      it 'リンク関連が正しく表示されている' do
+        expect(page).to have_link '新規登録', href: signup_path
+      end
+    end
+  end
+end

--- a/spec/system/guest/signup_spec.rb
+++ b/spec/system/guest/signup_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Signup' do
+RSpec.describe 'Guest::Signup' do
   let(:user) { create(:user) }
 
   before { visit signup_path }

--- a/spec/system/guest/signup_spec.rb
+++ b/spec/system/guest/signup_spec.rb
@@ -15,6 +15,12 @@ RSpec.describe 'Guest::Signup' do
         expect(page).to have_field 'パスワード', with: ''
         expect(page).to have_field 'パスワード（確認用）', with: ''
       end
+
+      it '共通レイアウトが正常に表示されている' do
+        expect(page).to have_link "Today's Course", href: top_path
+        expect(page).not_to have_link '新規登録', href: signup_path
+        expect(page).to have_link 'ログイン', href: login_path
+      end
     end
   end
 

--- a/spec/system/guest/signup_spec.rb
+++ b/spec/system/guest/signup_spec.rb
@@ -5,165 +5,183 @@ RSpec.describe 'Guest::Signup' do
 
   before { visit signup_path }
 
-  describe 'New' do
-    describe 'Validations' do
-      context '正常な値を入力する' do
+  describe 'Page' do
+    context '新規登録ページにアクセスする' do
+      it '情報が正しく表示されている' do
+        expect(page).to have_current_path signup_path
+        expect(page).to have_content '新規登録'
+      end
+    end
+  end
+
+  describe 'Contents' do
+    context '新規登録ページにアクセスする' do
+      it 'リンク関連が正しく表示されている' do
+        expect(page).to have_button '登録'
+        expect(find('form')['action']).to be_include users_path
+        expect(find('form')['method']).to eq 'post'
+        expect(page).not_to have_field('_method', type: 'hidden')
+      end
+    end
+  end
+
+  describe 'Validations' do
+    context '正常な値を入力する' do
+      it 'ユーザーの新規作成が成功し、プロフィールページに遷移する' do
+        fill_in '名前', with: 'user-name'
+        fill_in 'メールアドレス', with: 'user-email@example.com'
+        fill_in 'パスワード', with: 'user-password'
+        fill_in 'パスワード（確認用）', with: 'user-password'
+        click_button '登録'
+        expect(page).to have_content '新規作成に成功しました'
+        expect(page).to have_current_path profile_path
+      end
+    end
+
+    describe '#name' do
+      before do
+        fill_in 'メールアドレス', with: 'user-email@example.com'
+        fill_in 'パスワード', with: 'user-password'
+        fill_in 'パスワード（確認用）', with: 'user-password'
+      end
+
+      context '名前を入力しない' do
         it 'ユーザーの新規作成が成功し、プロフィールページに遷移する' do
-          fill_in '名前', with: 'user-name'
-          fill_in 'メールアドレス', with: 'user-email@example.com'
-          fill_in 'パスワード', with: 'user-password'
-          fill_in 'パスワード（確認用）', with: 'user-password'
           click_button '登録'
           expect(page).to have_content '新規作成に成功しました'
           expect(page).to have_current_path profile_path
         end
       end
 
-      describe '#name' do
-        before do
-          fill_in 'メールアドレス', with: 'user-email@example.com'
-          fill_in 'パスワード', with: 'user-password'
-          fill_in 'パスワード（確認用）', with: 'user-password'
-        end
-
-        context '名前を入力しない' do
-          it 'ユーザーの新規作成が成功し、プロフィールページに遷移する' do
-            click_button '登録'
-            expect(page).to have_content '新規作成に成功しました'
-            expect(page).to have_current_path profile_path
-          end
-        end
-
-        context '名前を50文字入力する' do
-          it 'ユーザーの新規作成が成功し、プロフィールページに遷移する' do
-            fill_in '名前', with: 'a' * 50
-            click_button '登録'
-            expect(page).to have_content '新規作成に成功しました'
-            expect(page).to have_current_path profile_path
-          end
-        end
-
-        context '名前を51文字入力する' do
-          it 'ユーザーの新規作成が失敗し、ページが遷移しない' do
-            fill_in '名前', with: 'a' * 51
-            click_button '登録'
-            expect(page).to have_content '名前は50文字以内で入力してください'
-            expect(page).to have_content '新規作成に失敗しました'
-            expect(page).to have_current_path signup_path
-          end
+      context '名前を50文字入力する' do
+        it 'ユーザーの新規作成が成功し、プロフィールページに遷移する' do
+          fill_in '名前', with: 'a' * 50
+          click_button '登録'
+          expect(page).to have_content '新規作成に成功しました'
+          expect(page).to have_current_path profile_path
         end
       end
 
-      describe '#email' do
-        before do
-          fill_in '名前', with: 'user-name'
-          fill_in 'パスワード', with: 'user-password'
-          fill_in 'パスワード（確認用）', with: 'user-password'
-        end
-
-        context 'メールアドレスを入力しない' do
-          it 'ユーザーの新規作成が失敗し、ページが遷移しない' do
-            click_button '登録'
-            expect(page).to have_content 'メールアドレスを入力してください'
-            expect(page).to have_content '新規作成に失敗しました'
-            expect(page).to have_current_path signup_path
-          end
-        end
-
-        context '重複したメールアドレスを入力する' do
-          it 'ユーザーの新規作成が失敗し、ページが遷移しない' do
-            fill_in 'メールアドレス', with: user.email
-            click_button '登録'
-            expect(page).to have_content 'メールアドレスはすでに存在します'
-            expect(page).to have_content '新規作成に失敗しました'
-            expect(page).to have_current_path signup_path
-          end
-        end
-      end
-
-      describe '#password, password_confirmation' do
-        before do
-          fill_in '名前', with: 'user-name'
-          fill_in 'メールアドレス', with: 'user-email@example.com'
-        end
-
-        context 'パスワードを入力しない' do
-          it 'ユーザーの新規作成が失敗し、ページが遷移しない' do
-            fill_in 'パスワード（確認用）', with: 'user-password'
-            click_button '登録'
-            expect(page).to have_content 'パスワードは3文字以上で入力してください'
-            expect(page).to have_content 'パスワード（確認用）とパスワードの入力が一致しません'
-            expect(page).to have_content '新規作成に失敗しました'
-            expect(page).to have_current_path signup_path
-          end
-        end
-
-        context 'パスワード（確認用）を入力しない' do
-          it 'ユーザーの新規作成が失敗し、ページが遷移しない' do
-            fill_in 'パスワード', with: 'user-password'
-            click_button '登録'
-            expect(page).to have_content 'パスワード（確認用）とパスワードの入力が一致しません'
-            expect(page).to have_content '新規作成に失敗しました'
-            expect(page).to have_current_path signup_path
-          end
-        end
-
-        context 'パスワードを2文字入力する' do
-          it 'ユーザーの新規作成が失敗し、ページが遷移しない' do
-            fill_in 'パスワード', with: 'a' * 2
-            fill_in 'パスワード（確認用）', with: 'a' * 2
-            click_button '登録'
-            expect(page).to have_content 'パスワードは3文字以上で入力してください'
-            expect(page).to have_content '新規作成に失敗しました'
-            expect(page).to have_current_path signup_path
-          end
-        end
-
-        context 'パスワードを3文字入力する' do
-          it 'ユーザーの新規作成が失敗し、ページが遷移しない' do
-            fill_in 'パスワード', with: 'a' * 3
-            fill_in 'パスワード（確認用）', with: 'a' * 3
-            click_button '登録'
-            expect(page).to have_content '新規作成に成功しました'
-            expect(page).to have_current_path profile_path
-          end
+      context '名前を51文字入力する' do
+        it 'ユーザーの新規作成が失敗し、ページが遷移しない' do
+          fill_in '名前', with: 'a' * 51
+          click_button '登録'
+          expect(page).to have_content '名前は50文字以内で入力してください'
+          expect(page).to have_content '新規作成に失敗しました'
+          expect(page).to have_current_path signup_path
         end
       end
     end
 
-    describe 'Form' do
-      context '名前を入力し、新規作成に失敗する' do
-        it 'フォームから入力した名前が消えていない' do
-          name = 'user-name'
-          fill_in '名前', with: name
+    describe '#email' do
+      before do
+        fill_in '名前', with: 'user-name'
+        fill_in 'パスワード', with: 'user-password'
+        fill_in 'パスワード（確認用）', with: 'user-password'
+      end
+
+      context 'メールアドレスを入力しない' do
+        it 'ユーザーの新規作成が失敗し、ページが遷移しない' do
           click_button '登録'
-          expect(page).to have_field '名前', with: name
+          expect(page).to have_content 'メールアドレスを入力してください'
+          expect(page).to have_content '新規作成に失敗しました'
+          expect(page).to have_current_path signup_path
         end
       end
 
-      context 'メールアドレスを入力し、新規作成に失敗する' do
-        it 'フォームから入力した名前が消えていない' do
-          email = 'user-email@example.com'
-          fill_in 'メールアドレス', with: email
+      context '重複したメールアドレスを入力する' do
+        it 'ユーザーの新規作成が失敗し、ページが遷移しない' do
+          fill_in 'メールアドレス', with: user.email
           click_button '登録'
-          expect(page).to have_field 'メールアドレス', with: email
+          expect(page).to have_content 'メールアドレスはすでに存在します'
+          expect(page).to have_content '新規作成に失敗しました'
+          expect(page).to have_current_path signup_path
         end
       end
+    end
 
-      context 'パスワードを入力し、新規作成に失敗する' do
-        it '入力したパスワードがフォームから消えている' do
-          fill_in 'パスワード', with: 'user-password'
-          click_button '登録'
-          expect(page).to have_field 'パスワード', with: ''
-        end
+    describe '#password, password_confirmation' do
+      before do
+        fill_in '名前', with: 'user-name'
+        fill_in 'メールアドレス', with: 'user-email@example.com'
       end
 
-      context 'パスワード（確認用）を入力し、新規作成に失敗する' do
-        it '入力したパスワード（確認用）がフォームから消えている' do
+      context 'パスワードを入力しない' do
+        it 'ユーザーの新規作成が失敗し、ページが遷移しない' do
           fill_in 'パスワード（確認用）', with: 'user-password'
           click_button '登録'
-          expect(page).to have_field 'パスワード（確認用）', with: ''
+          expect(page).to have_content 'パスワードは3文字以上で入力してください'
+          expect(page).to have_content 'パスワード（確認用）とパスワードの入力が一致しません'
+          expect(page).to have_content '新規作成に失敗しました'
+          expect(page).to have_current_path signup_path
         end
+      end
+
+      context 'パスワード（確認用）を入力しない' do
+        it 'ユーザーの新規作成が失敗し、ページが遷移しない' do
+          fill_in 'パスワード', with: 'user-password'
+          click_button '登録'
+          expect(page).to have_content 'パスワード（確認用）とパスワードの入力が一致しません'
+          expect(page).to have_content '新規作成に失敗しました'
+          expect(page).to have_current_path signup_path
+        end
+      end
+
+      context 'パスワードを2文字入力する' do
+        it 'ユーザーの新規作成が失敗し、ページが遷移しない' do
+          fill_in 'パスワード', with: 'a' * 2
+          fill_in 'パスワード（確認用）', with: 'a' * 2
+          click_button '登録'
+          expect(page).to have_content 'パスワードは3文字以上で入力してください'
+          expect(page).to have_content '新規作成に失敗しました'
+          expect(page).to have_current_path signup_path
+        end
+      end
+
+      context 'パスワードを3文字入力する' do
+        it 'ユーザーの新規作成が失敗し、ページが遷移しない' do
+          fill_in 'パスワード', with: 'a' * 3
+          fill_in 'パスワード（確認用）', with: 'a' * 3
+          click_button '登録'
+          expect(page).to have_content '新規作成に成功しました'
+          expect(page).to have_current_path profile_path
+        end
+      end
+    end
+  end
+
+  describe 'Form' do
+    context '名前を入力し、新規作成に失敗する' do
+      it 'フォームから入力した名前が消えていない' do
+        name = 'user-name'
+        fill_in '名前', with: name
+        click_button '登録'
+        expect(page).to have_field '名前', with: name
+      end
+    end
+
+    context 'メールアドレスを入力し、新規作成に失敗する' do
+      it 'フォームから入力した名前が消えていない' do
+        email = 'user-email@example.com'
+        fill_in 'メールアドレス', with: email
+        click_button '登録'
+        expect(page).to have_field 'メールアドレス', with: email
+      end
+    end
+
+    context 'パスワードを入力し、新規作成に失敗する' do
+      it '入力したパスワードがフォームから消えている' do
+        fill_in 'パスワード', with: 'user-password'
+        click_button '登録'
+        expect(page).to have_field 'パスワード', with: ''
+      end
+    end
+
+    context 'パスワード（確認用）を入力し、新規作成に失敗する' do
+      it '入力したパスワード（確認用）がフォームから消えている' do
+        fill_in 'パスワード（確認用）', with: 'user-password'
+        click_button '登録'
+        expect(page).to have_field 'パスワード（確認用）', with: ''
       end
     end
   end

--- a/spec/system/guest/signup_spec.rb
+++ b/spec/system/guest/signup_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe 'Guest::Signup' do
       it '情報が正しく表示されている' do
         expect(page).to have_current_path signup_path
         expect(page).to have_content '新規登録'
+        expect(page).to have_field '名前', with: ''
+        expect(page).to have_field 'メールアドレス', with: ''
+        expect(page).to have_field 'パスワード', with: ''
+        expect(page).to have_field 'パスワード（確認用）', with: ''
       end
     end
   end

--- a/spec/system/guest/tops_spec.rb
+++ b/spec/system/guest/tops_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe 'Guest::Tops' do
       end
 
       it '共通レイアウトが正常に表示されている' do
-        verify_guest_layout
+        expect(page).to have_link "Today's Course", href: top_path
+        expect(page).to have_link '新規登録', href: signup_path
+        expect(page).to have_link 'ログイン', href: login_path
       end
     end
   end

--- a/spec/system/guest/tops_spec.rb
+++ b/spec/system/guest/tops_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe 'Guest::Tops' do
+  before { visit top_path }
+
+  describe 'Page' do
+    context 'トップページにアクセスする' do
+      it '情報が正しく表示されている' do
+        expect(page).to have_current_path top_path
+      end
+    end
+  end
+
+  describe 'Contents' do
+    context 'トップページにアクセスする' do
+      it 'リンク関連が正しく表示されている' do
+        expect(page).to have_link "Today's Course", href: top_path
+        expect(page).to have_link '新規登録', href: signup_path
+        expect(page).to have_link 'ログイン', href: login_path
+        expect(page).to have_link 'ログインせずに目的地を探してみる', href: new_guest_path
+        expect(page).to have_link 'まずは試してみる', href: new_guest_path
+        expect(page).to have_link '新規登録してみる', href: signup_path
+        expect(page).to have_link '利用規約', href: terms_path
+        expect(page).to have_link 'プライバシーポリシー', href: 'https://kiyac.app/privacypolicy/MJIjHojL1fFp8ok7HOLL'
+        expect(page).to have_link 'お問い合わせ', href: 'https://twitter.com/KoukiGyunyu'
+      end
+    end
+  end
+end

--- a/spec/system/guest/tops_spec.rb
+++ b/spec/system/guest/tops_spec.rb
@@ -8,15 +8,16 @@ RSpec.describe 'Guest::Tops' do
       it '情報が正しく表示されている' do
         expect(page).to have_current_path top_path
       end
+
+      it '共通レイアウトが正常に表示されている' do
+        verify_guest_layout
+      end
     end
   end
 
   describe 'Contents' do
     context 'トップページにアクセスする' do
       it 'リンク関連が正しく表示されている' do
-        expect(page).to have_link "Today's Course", href: top_path
-        expect(page).to have_link '新規登録', href: signup_path
-        expect(page).to have_link 'ログイン', href: login_path
         expect(page).to have_link 'ログインせずに目的地を探してみる', href: new_guest_path
         expect(page).to have_link 'まずは試してみる', href: new_guest_path
         expect(page).to have_link '新規登録してみる', href: signup_path

--- a/spec/system/profile/histories_spec.rb
+++ b/spec/system/profile/histories_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Profile::Histories' do
       it '情報が正しく表示されている' do
         histories = create_list(:history, 5, user:)
         login(histories.first.user)
-        sleep(0.2)
+        sleep(0.1)
         expect(page).to have_current_path profile_path
         expect(page).to have_content "#{histories.first.user.name}さん"
         expect(page).to have_content "総移動時間: #{histories.sum { |history| history.decorate.moving_time }}分"
@@ -91,7 +91,7 @@ RSpec.describe 'Profile::Histories' do
       visit_histories_page(history)
       find('.fa.fa-chevron-down').click
       click_link('編集')
-      sleep(0.2)
+      sleep(0.1)
     end
 
     describe 'Validations' do

--- a/spec/system/profile/histories_spec.rb
+++ b/spec/system/profile/histories_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe 'Profile::Histories' do
 
       it '共通レイアウトが正常に表示されている' do
         login(user)
-        verify_user_layout
+        expect(nav_search_icon).to eq new_departure_path
+        expect(nav_folder_icon).to eq departures_path
+        expect(nav_user_icon).to eq profile_path
       end
     end
 

--- a/spec/system/profile/histories_spec.rb
+++ b/spec/system/profile/histories_spec.rb
@@ -18,6 +18,18 @@ RSpec.describe 'Profile::Histories' do
         expect(page).to have_content '設定'
       end
     end
+
+    context '履歴のページにアクセスし、編集状態にする' do
+      it '情報が正しく表示されている' do
+        visit_histories_page(history)
+        find('.fa.fa-chevron-down').click
+        click_link('編集')
+        expect(page).to have_field '開始時刻'
+        expect(page).to have_field '終了時刻'
+        expect(page).to have_field 'コメント'
+        expect(page).to have_field '移動距離'
+      end
+    end
   end
 
   describe 'Contents' do
@@ -91,7 +103,6 @@ RSpec.describe 'Profile::Histories' do
       visit_histories_page(history)
       find('.fa.fa-chevron-down').click
       click_link('編集')
-      sleep(0.1)
     end
 
     describe 'Validations' do
@@ -303,7 +314,6 @@ RSpec.describe 'Profile::Histories' do
     before do
       visit_histories_page(history)
       find('.fa.fa-chevron-down').click
-      sleep(0.1)
     end
 
     context '削除ボタンをクリックする' do
@@ -333,7 +343,6 @@ RSpec.describe 'Profile::Histories' do
       it 'データベースから履歴が正常に削除される' do
         visit_histories_page(history)
         find('.fa.fa-chevron-down').click
-        sleep(0.1)
         page.accept_confirm("履歴から削除します\nよろしいですか?") do
           click_link '削除'
         end

--- a/spec/system/profile/histories_spec.rb
+++ b/spec/system/profile/histories_spec.rb
@@ -17,6 +17,11 @@ RSpec.describe 'Profile::Histories' do
         expect(page).to have_content '履歴'
         expect(page).to have_content '設定'
       end
+
+      it '共通レイアウトが正常に表示されている' do
+        login(user)
+        verify_user_layout
+      end
     end
 
     context '履歴のページにアクセスし、編集状態にする' do

--- a/spec/system/profile/histories_spec.rb
+++ b/spec/system/profile/histories_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe 'Profile::Histories' do
       before { visit_histories_page(history) }
 
       it '情報が正しく表示されている' do
-        expect(page).to have_current_path profile_path
         expect(page).to have_content history.destination.name
         expect(page).to have_content history.destination.address
         expect(page).to have_css '.fa.fa-eye-slash'
@@ -44,6 +43,7 @@ RSpec.describe 'Profile::Histories' do
         find('.fa.fa-chevron-down').click
         expect(page).to have_link '編集', href: edit_history_path(history.uuid, route: 'profile_page')
         expect(page).to have_link '削除', href: history_path(history.uuid, route: 'profile_page')
+        expect(find('a', text: '削除')['data-turbo-method']).to eq 'delete'
         click_link '編集'
         expect(page).to have_link '取消', href: cancel_history_path(history.uuid, route: 'profile_page')
         expect(page).to have_button '更新'

--- a/spec/system/profile/histories_spec.rb
+++ b/spec/system/profile/histories_spec.rb
@@ -327,4 +327,19 @@ RSpec.describe 'Profile::Histories' do
       end
     end
   end
+
+  describe 'Database' do
+    context '履歴を削除する' do
+      it 'データベースから履歴が正常に削除される' do
+        visit_histories_page(history)
+        find('.fa.fa-chevron-down').click
+        sleep(0.1)
+        page.accept_confirm("履歴から削除します\nよろしいですか?") do
+          click_link '削除'
+        end
+        sleep(0.1)
+        expect(History.find_by(id: history.id)).to be_nil
+      end
+    end
+  end
 end

--- a/spec/system/profile/settings_spec.rb
+++ b/spec/system/profile/settings_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe 'Profile::Settings' do
         expect(page).to have_content '設定'
       end
     end
+
+    context 'プロフィールページにアクセスし、編集状態にする' do
+      it '情報が正しく表示されている' do
+        click_link '編集'
+        expect(page).to have_field '名前'
+        expect(page).to have_field 'メールアドレス'
+      end
+    end
   end
 
   describe 'Contents' do

--- a/spec/system/profile/settings_spec.rb
+++ b/spec/system/profile/settings_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe 'Profile::Settings' do
 
       it '共通レイアウトが正常に表示されている' do
         login(user)
-        verify_user_layout
+        expect(nav_search_icon).to eq new_departure_path
+        expect(nav_folder_icon).to eq departures_path
+        expect(nav_user_icon).to eq profile_path
       end
     end
 

--- a/spec/system/profile/settings_spec.rb
+++ b/spec/system/profile/settings_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'Profile::Settings' do
   describe 'ユーザー設定' do
     before { login(user) }
 
-    context 'ログアウトする' do
+    context 'Logout' do
       it '正常にログアウトし、ログインページに戻る' do
         find('label[for=right]').click
         page.accept_confirm('ログアウトしますか？') do
@@ -108,6 +108,20 @@ RSpec.describe 'Profile::Settings' do
             click_button '更新'
             expect(page).to have_field 'メールアドレス', with: email
           end
+        end
+      end
+    end
+
+    describe 'Delete' do
+      context 'ユーザー削除する' do
+        it '正常にユーザーを削除し、サインアップページに戻る' do
+          find('label[for=right]').click
+          find('.fa.fa-chevron-down').click
+          page.accept_confirm("データは全て削除され、戻すことはできません。\n削除しますか？") do
+            click_link 'ユーザー削除'
+          end
+          expect(page).to have_content 'ユーザーを削除しました'
+          expect(page).to have_current_path signup_path
         end
       end
     end

--- a/spec/system/profile/settings_spec.rb
+++ b/spec/system/profile/settings_spec.rb
@@ -3,12 +3,44 @@ require 'rails_helper'
 RSpec.describe 'Profile::Settings' do
   let(:user) { create(:user) }
 
-  before { login(user) }
+  before do
+    login(user)
+    find('label[for=right]').click
+  end
+
+  describe 'Page' do
+    context 'プロフィールページにアクセスし、設定のタブを開く' do
+      it '情報が正しく表示されている' do
+        expect(page).to have_current_path profile_path
+        histories = create_list(:history, 5, user:)
+        login(histories.first.user)
+        sleep(0.1)
+        expect(page).to have_current_path profile_path
+        expect(page).to have_content "#{histories.first.user.name}さん"
+        expect(page).to have_content "総移動時間: #{histories.sum { |history| history.decorate.moving_time }}分"
+        expect(page).to have_content "総移動距離: #{histories.sum(&:moving_distance)}m"
+        expect(page).to have_content '履歴'
+        expect(page).to have_content '設定'
+      end
+    end
+  end
+
+  describe 'Contents' do
+    context 'プロフィールページにアクセスし、設定のタブを開く' do
+      it 'リンク関連が正しく表示されている' do
+        expect(page).to have_link '編集', href: edit_profile_path
+        expect(page).to have_link 'ログアウト', href: logout_path
+        expect(find('a', text: 'ログアウト')['data-turbo-method']).to eq 'delete'
+        find('.fa.fa-chevron-down').click
+        expect(page).to have_link 'ユーザー削除', href: profile_path
+        expect(find('a', text: 'ユーザー削除')['data-turbo-method']).to eq 'delete'
+      end
+    end
+  end
 
   describe 'Logout' do
     context 'ログアウトをクリックする' do
       it '正常にログアウトし、ログインページに戻る' do
-        find('label[for=right]').click
         page.accept_confirm('ログアウトしますか？') do
           click_link 'ログアウト'
         end
@@ -19,10 +51,7 @@ RSpec.describe 'Profile::Settings' do
   end
 
   describe 'Edit' do
-    before do
-      find('label[for=right]').click
-      click_link '編集'
-    end
+    before { click_link '編集' }
 
     describe 'Validations' do
       context '正常な値を入力する' do
@@ -116,7 +145,6 @@ RSpec.describe 'Profile::Settings' do
   describe 'Delete' do
     context 'ユーザー削除する' do
       it '正常にユーザーを削除し、サインアップページに戻る' do
-        find('label[for=right]').click
         find('.fa.fa-chevron-down').click
         page.accept_confirm("データは全て削除され、戻すことはできません。\n削除しますか？") do
           click_link 'ユーザー削除'
@@ -130,7 +158,6 @@ RSpec.describe 'Profile::Settings' do
   describe 'Database' do
     context 'ユーザーを削除する' do
       it 'データベースからユーザーが正常に削除される' do
-        find('label[for=right]').click
         find('.fa.fa-chevron-down').click
         page.accept_confirm("データは全て削除され、戻すことはできません。\n削除しますか？") do
           click_link 'ユーザー削除'

--- a/spec/system/profile/settings_spec.rb
+++ b/spec/system/profile/settings_spec.rb
@@ -3,10 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Profile::Settings' do
   let(:user) { create(:user) }
 
-  before do
-    login(user)
-    find('label[for=right]').click
-  end
+  before { visit_setting_page(user) }
 
   describe 'Page' do
     context 'プロフィールページにアクセスし、設定のタブを開く' do

--- a/spec/system/profile/settings_spec.rb
+++ b/spec/system/profile/settings_spec.rb
@@ -3,10 +3,10 @@ require 'rails_helper'
 RSpec.describe 'Profile::Settings' do
   let(:user) { create(:user) }
 
-  describe 'ユーザー設定' do
-    before { login(user) }
+  before { login(user) }
 
-    context 'Logout' do
+  describe 'Logout' do
+    context 'ログアウトをクリックする' do
       it '正常にログアウトし、ログインページに戻る' do
         find('label[for=right]').click
         page.accept_confirm('ログアウトしますか？') do
@@ -16,113 +16,127 @@ RSpec.describe 'Profile::Settings' do
         expect(page).to have_current_path login_path
       end
     end
+  end
 
-    describe 'Edit' do
-      before do
-        find('label[for=right]').click
-        click_link '編集'
+  describe 'Edit' do
+    before do
+      find('label[for=right]').click
+      click_link '編集'
+    end
+
+    describe 'Validations' do
+      context '正常な値を入力する' do
+        it 'プロフィールの更新が成功し、プロフィールページに戻る' do
+          fill_in '名前', with: 'user-name-update'
+          fill_in 'メールアドレス', with: 'user-email-update@example.com'
+          click_button '更新'
+          expect(page).to have_content '編集'
+          expect(page).to have_current_path profile_path
+        end
       end
 
-      describe 'Validations' do
-        context '正常な値を入力する' do
+      describe '#name' do
+        context '名前を入力しない' do
           it 'プロフィールの更新が成功し、プロフィールページに戻る' do
-            fill_in '名前', with: 'user-name-update'
-            fill_in 'メールアドレス', with: 'user-email-update@example.com'
+            fill_in '名前', with: ''
             click_button '更新'
             expect(page).to have_content '編集'
             expect(page).to have_current_path profile_path
           end
         end
 
-        describe '#name' do
-          context '名前を入力しない' do
-            it 'プロフィールの更新が成功し、プロフィールページに戻る' do
-              fill_in '名前', with: ''
-              click_button '更新'
-              expect(page).to have_content '編集'
-              expect(page).to have_current_path profile_path
-            end
-          end
-
-          context '名前を50文字入力する' do
-            it 'プロフィールの更新が成功し、プロフィールページに戻る' do
-              fill_in '名前', with: 'a' * 50
-              click_button '更新'
-              expect(page).to have_content '編集'
-              expect(page).to have_current_path profile_path
-            end
-          end
-
-          context '名前を51文字入力する' do
-            it 'プロフィールの更新が失敗し、フォームが表示されたままになる' do
-              fill_in '名前', with: 'a' * 51
-              click_button '更新'
-              expect(page).to have_content '入力情報に誤りがあります'
-              expect(page).to have_content '名前は50文字以内で入力してください'
-              expect(page).to have_button '更新'
-              expect(page).to have_current_path profile_path
-            end
+        context '名前を50文字入力する' do
+          it 'プロフィールの更新が成功し、プロフィールページに戻る' do
+            fill_in '名前', with: 'a' * 50
+            click_button '更新'
+            expect(page).to have_content '編集'
+            expect(page).to have_current_path profile_path
           end
         end
 
-        describe '#email' do
-          context 'メールアドレスを入力しない' do
-            it 'プロフィールの更新が失敗し、フォームが表示されたままになる' do
-              fill_in 'メールアドレス', with: ''
-              click_button '更新'
-              expect(page).to have_content '入力情報に誤りがあります'
-              expect(page).to have_content 'メールアドレスを入力してください'
-              expect(page).to have_button '更新'
-              expect(page).to have_current_path profile_path
-            end
-          end
-
-          context '重複したメールアドレスを入力する' do
-            it 'プロフィールの更新が失敗し、フォームが表示されたままになる' do
-              duplicate_user = create(:user)
-              fill_in 'メールアドレス', with: duplicate_user.email
-              click_button '更新'
-              expect(page).to have_content '入力情報に誤りがあります'
-              expect(page).to have_content 'メールアドレスはすでに存在します'
-              expect(page).to have_button '更新'
-              expect(page).to have_current_path profile_path
-            end
+        context '名前を51文字入力する' do
+          it 'プロフィールの更新が失敗し、フォームが表示されたままになる' do
+            fill_in '名前', with: 'a' * 51
+            click_button '更新'
+            expect(page).to have_content '入力情報に誤りがあります'
+            expect(page).to have_content '名前は50文字以内で入力してください'
+            expect(page).to have_button '更新'
+            expect(page).to have_current_path profile_path
           end
         end
       end
 
-      describe 'Form' do
-        context '名前を入力し、更新に失敗する' do
-          it 'フォームから入力した名前が消えていない' do
-            name = 'a' * 51
-            fill_in '名前', with: name
+      describe '#email' do
+        context 'メールアドレスを入力しない' do
+          it 'プロフィールの更新が失敗し、フォームが表示されたままになる' do
+            fill_in 'メールアドレス', with: ''
             click_button '更新'
-            expect(page).to have_field '名前', with: name
+            expect(page).to have_content '入力情報に誤りがあります'
+            expect(page).to have_content 'メールアドレスを入力してください'
+            expect(page).to have_button '更新'
+            expect(page).to have_current_path profile_path
           end
         end
 
-        context 'メールアドレスを入力し、更新に失敗する' do
-          it 'フォームから入力したメールアドレスが消えていない' do
-            email = create(:user).email
-            fill_in 'メールアドレス', with: email
+        context '重複したメールアドレスを入力する' do
+          it 'プロフィールの更新が失敗し、フォームが表示されたままになる' do
+            duplicate_user = create(:user)
+            fill_in 'メールアドレス', with: duplicate_user.email
             click_button '更新'
-            expect(page).to have_field 'メールアドレス', with: email
+            expect(page).to have_content '入力情報に誤りがあります'
+            expect(page).to have_content 'メールアドレスはすでに存在します'
+            expect(page).to have_button '更新'
+            expect(page).to have_current_path profile_path
           end
         end
       end
     end
 
-    describe 'Delete' do
-      context 'ユーザー削除する' do
-        it '正常にユーザーを削除し、サインアップページに戻る' do
-          find('label[for=right]').click
-          find('.fa.fa-chevron-down').click
-          page.accept_confirm("データは全て削除され、戻すことはできません。\n削除しますか？") do
-            click_link 'ユーザー削除'
-          end
-          expect(page).to have_content 'ユーザーを削除しました'
-          expect(page).to have_current_path signup_path
+    describe 'Form' do
+      context '名前を入力し、更新に失敗する' do
+        it 'フォームから入力した名前が消えていない' do
+          name = 'a' * 51
+          fill_in '名前', with: name
+          click_button '更新'
+          expect(page).to have_field '名前', with: name
         end
+      end
+
+      context 'メールアドレスを入力し、更新に失敗する' do
+        it 'フォームから入力したメールアドレスが消えていない' do
+          email = create(:user).email
+          fill_in 'メールアドレス', with: email
+          click_button '更新'
+          expect(page).to have_field 'メールアドレス', with: email
+        end
+      end
+    end
+  end
+
+  describe 'Delete' do
+    context 'ユーザー削除する' do
+      it '正常にユーザーを削除し、サインアップページに戻る' do
+        find('label[for=right]').click
+        find('.fa.fa-chevron-down').click
+        page.accept_confirm("データは全て削除され、戻すことはできません。\n削除しますか？") do
+          click_link 'ユーザー削除'
+        end
+        expect(page).to have_content 'ユーザーを削除しました'
+        expect(page).to have_current_path signup_path
+      end
+    end
+  end
+
+  describe 'Database' do
+    context 'ユーザーを削除する' do
+      it 'データベースからユーザーが正常に削除される' do
+        find('label[for=right]').click
+        find('.fa.fa-chevron-down').click
+        page.accept_confirm("データは全て削除され、戻すことはできません。\n削除しますか？") do
+          click_link 'ユーザー削除'
+        end
+        sleep(0.1)
+        expect(User.find_by(id: user.id)).to be_nil
       end
     end
   end

--- a/spec/system/profile/settings_spec.rb
+++ b/spec/system/profile/settings_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe 'Profile::Settings' do
         expect(page).to have_content '履歴'
         expect(page).to have_content '設定'
       end
+
+      it '共通レイアウトが正常に表示されている' do
+        login(user)
+        verify_user_layout
+      end
     end
 
     context 'プロフィールページにアクセスし、編集状態にする' do

--- a/spec/system/saved/departures_spec.rb
+++ b/spec/system/saved/departures_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe 'Saved::Departures' do
       end
 
       it '共通レイアウトが正常に表示されている' do
-        verify_user_layout
+        expect(nav_search_icon).to eq new_departure_path
+        expect(nav_folder_icon).to eq departures_path
+        expect(nav_user_icon).to eq profile_path
       end
     end
 

--- a/spec/system/saved/departures_spec.rb
+++ b/spec/system/saved/departures_spec.rb
@@ -16,6 +16,14 @@ RSpec.describe 'Saved::Departures' do
         expect(page).to have_content '目的地'
       end
     end
+
+    context '保存済み出発地のページにアクセスし、編集状態にする' do
+      it '情報が正しく表示されている' do
+        visit_edit_departure_page(departure)
+        expect(page).to have_field '名称'
+        expect(page).to have_field '住所'
+      end
+    end
   end
 
   describe 'Contents' do

--- a/spec/system/saved/departures_spec.rb
+++ b/spec/system/saved/departures_spec.rb
@@ -25,7 +25,6 @@ RSpec.describe 'Saved::Departures' do
       before { visit_saved_departures_page(departure) }
 
       it '情報が正しく表示されている' do
-        expect(page).to have_current_path departures_path
         expect(page).to have_content departure.name
         expect(page).to have_content departure.address
         expect(page).to have_content I18n.l(departure.created_at, format: :short)
@@ -36,6 +35,7 @@ RSpec.describe 'Saved::Departures' do
         find('.fa.fa-chevron-down').click
         expect(page).to have_link '編集', href: edit_departure_path(departure.uuid)
         expect(page).to have_link '削除', href: departure_path(departure.uuid)
+        expect(find('a', text: '削除')['data-turbo-method']).to eq 'delete'
         click_link '編集'
         expect(page).to have_link '取消', href: departure_path(departure.uuid)
         expect(page).to have_button '更新'

--- a/spec/system/saved/departures_spec.rb
+++ b/spec/system/saved/departures_spec.rb
@@ -6,14 +6,19 @@ RSpec.describe 'Saved::Departures' do
 
   describe 'Page' do
     context '保存済み出発地のページにアクセスする' do
+      before { login(user) }
+
       it '情報が正しく表示されている' do
-        login(user)
         sleep(0.1)
         find('.fa.fa-folder-open.nav-icon').click
         expect(page).to have_current_path departures_path
         expect(page).to have_content '保存済み'
         expect(page).to have_content '出発地'
         expect(page).to have_content '目的地'
+      end
+
+      it '共通レイアウトが正常に表示されている' do
+        verify_user_layout
       end
     end
 

--- a/spec/system/saved/departures_spec.rb
+++ b/spec/system/saved/departures_spec.rb
@@ -243,4 +243,19 @@ RSpec.describe 'Saved::Departures' do
       end
     end
   end
+
+  describe 'Database' do
+    context '出発地を削除する' do
+      it '出発地が保存しないに変更される' do
+        visit_saved_departures_page(departure)
+        find('.fa.fa-chevron-down').click
+        sleep(0.1)
+        page.accept_confirm("保存済みから削除します\nよろしいですか?") do
+          click_link '削除'
+        end
+        sleep(0.1)
+        expect(Departure.find_by(id: departure.id).is_saved).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/system/saved/destinations_spec.rb
+++ b/spec/system/saved/destinations_spec.rb
@@ -16,6 +16,16 @@ RSpec.describe 'Saved::Destinations' do
         expect(page).to have_content '目的地'
       end
     end
+
+    context '保存済み目的地のページにアクセスし、編集状態にする' do
+      it '情報が正しく表示されている' do
+        visit_edit_destination_page(destination)
+        expect(page).to have_field '名称'
+        expect(page).to have_field 'コメント'
+        expect(page).to have_checked_field 'コメントを公開する'
+        expect(page).to have_field '片道の距離'
+      end
+    end
   end
 
   describe 'Contents' do
@@ -104,12 +114,7 @@ RSpec.describe 'Saved::Destinations' do
   describe 'Edit' do
     let(:build_another_destination) { create(:destination, :another, :published_comment) }
 
-    before do
-      visit_saved_destinations_page(destination)
-      find('.fa.fa-chevron-down').click
-      click_link('編集')
-      sleep(0.1)
-    end
+    before { visit_edit_destination_page(destination) }
 
     describe 'Validations' do
       context '正常な値を入力する' do

--- a/spec/system/saved/destinations_spec.rb
+++ b/spec/system/saved/destinations_spec.rb
@@ -394,4 +394,19 @@ RSpec.describe 'Saved::Destinations' do
       end
     end
   end
+
+  describe 'Database' do
+    context '目的地を削除する' do
+      it '目的地が保存しないに変更される' do
+        visit_saved_destinations_page(destination)
+        find('.fa.fa-chevron-down').click
+        sleep(0.1)
+        page.accept_confirm("保存済みから削除します\nよろしいですか?") do
+          click_link '削除'
+        end
+        sleep(0.1)
+        expect(Destination.find_by(id: destination.id).is_saved).to be_falsey
+      end
+    end
+  end
 end

--- a/spec/system/saved/destinations_spec.rb
+++ b/spec/system/saved/destinations_spec.rb
@@ -6,14 +6,19 @@ RSpec.describe 'Saved::Destinations' do
 
   describe 'Page' do
     context '保存済み目的地のページにアクセスする' do
+      before { login(user) }
+
       it '情報が正しく表示されている' do
-        login(user)
         sleep(0.1)
         find('.fa.fa-folder-open.nav-icon').click
         expect(page).to have_current_path departures_path
         expect(page).to have_content '保存済み'
         expect(page).to have_content '出発地'
         expect(page).to have_content '目的地'
+      end
+
+      it '共通レイアウトが正常に表示されている' do
+        verify_user_layout
       end
     end
 

--- a/spec/system/saved/destinations_spec.rb
+++ b/spec/system/saved/destinations_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe 'Saved::Destinations' do
         find('.fa.fa-chevron-down').click
         expect(page).to have_link '編集', href: edit_destination_path(destination.uuid, route: 'saved_page')
         expect(page).to have_link '削除', href: destination_path(destination.uuid, route: 'saved_page')
+        expect(find('a', text: '削除')['data-turbo-method']).to eq 'delete'
         click_link '編集'
         expect(page).to have_link '取消', href: destination_path(destination.uuid, route: 'saved_page')
         expect(page).to have_button '更新'

--- a/spec/system/saved/destinations_spec.rb
+++ b/spec/system/saved/destinations_spec.rb
@@ -18,7 +18,9 @@ RSpec.describe 'Saved::Destinations' do
       end
 
       it '共通レイアウトが正常に表示されている' do
-        verify_user_layout
+        expect(nav_search_icon).to eq new_departure_path
+        expect(nav_folder_icon).to eq departures_path
+        expect(nav_user_icon).to eq profile_path
       end
     end
 

--- a/spec/system/search/goals_spec.rb
+++ b/spec/system/search/goals_spec.rb
@@ -7,9 +7,14 @@ RSpec.describe 'Search::Goals' do
 
   describe 'Page' do
     context 'スタートし、ゴールページに遷移する' do
+      before { visit_goal_page_from_not_finished(not_finished_history) }
+
       it '情報が正しく表示されている' do
-        visit_goal_page_from_not_finished(not_finished_history)
         expect(page).to have_current_path history_path(not_finished_history.uuid)
+      end
+
+      it '共通レイアウトが正常に表示されている' do
+        verify_user_layout
       end
     end
   end

--- a/spec/system/search/goals_spec.rb
+++ b/spec/system/search/goals_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe 'Search::Goals' do
   let(:departure) { create(:departure) }
   let(:destination) { create(:destination, departure: departure, user: departure.user) }
   let(:not_finished_history) { create(:history, :not_finished, destination: destination, user: destination.user) }
-  # let(:history) { create(:history, destination: destination, user: destination.user) }
 
   describe 'Page' do
     context 'スタートし、ゴールページに遷移する' do
@@ -33,6 +32,34 @@ RSpec.describe 'Search::Goals' do
         expect(find('a', text: 'ゴール')['data-turbo-method']).to eq 'patch'
         expect(page).to have_link 'やめる', href: history_path(not_finished_history.uuid, route: 'moving_page')
         expect(find('a', text: 'やめる')['data-turbo-method']).to eq 'delete'
+      end
+    end
+  end
+
+  describe 'Goal' do
+    before { visit_goal_page_from_not_finished(not_finished_history) }
+
+    context 'ゴールする' do
+      it 'ゴールした履歴が表示される' do
+        click_link 'ゴール'
+        expect(page).to have_current_path history_path(not_finished_history.uuid)
+        expect(page).to have_content 'ゴールしました'
+        expect(page).to have_content "GOAL: #{I18n.l(History.last.end_time, format: :short)}"
+      end
+    end
+  end
+
+  describe 'Cancel' do
+    before { visit_goal_page_from_not_finished(not_finished_history) }
+
+    context 'やめるをクリックする' do
+      it '履歴が削除され、スタートページに遷移する' do
+        page.accept_confirm("スタート記録は削除されます。\nよろしいですか？") do
+          click_link 'やめる'
+        end
+        expect(page).to have_current_path new_history_path(destination: not_finished_history.destination.uuid)
+        expect(page).to have_content '取り消しました'
+        expect(page).to have_content not_finished_history.destination.name
       end
     end
   end

--- a/spec/system/search/goals_spec.rb
+++ b/spec/system/search/goals_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'Search::Goals' do
+  let(:departure) { create(:departure) }
+  let(:destination) { create(:destination, departure: departure, user: departure.user) }
+  let(:not_finished_history) { create(:history, :not_finished, destination: destination, user: destination.user) }
+  # let(:history) { create(:history, destination: destination, user: destination.user) }
+
+  describe 'Page' do
+    context 'スタートし、ゴールページに遷移する' do
+      it '情報が正しく表示されている' do
+        visit_goal_page_from_not_finished(not_finished_history)
+        expect(page).to have_current_path history_path(not_finished_history.uuid)
+      end
+    end
+  end
+
+  describe 'Contents' do
+    before { visit_goal_page_from_not_finished(not_finished_history) }
+
+    context 'スタートし、ゴールページに遷移する' do
+      it 'コンテンツが正しく表示されている' do
+        visit_goal_page_from_not_finished(not_finished_history)
+        expect(page).to have_content not_finished_history.destination.name
+        expect(page).to have_content "#{not_finished_history.moving_distance}m"
+        expect(page).to have_content not_finished_history.destination.address
+        expect(page).to have_content "START: #{I18n.l(not_finished_history.start_time, format: :short)}"
+        expect(page).to have_content not_finished_history.departure.name
+      end
+
+      it 'リンク関連が正しく表示されている' do
+        expect(page).to have_link 'ゴール', href: history_path(not_finished_history.uuid)
+        expect(find('a', text: 'ゴール')['data-turbo-method']).to eq 'patch'
+        expect(page).to have_link 'やめる', href: history_path(not_finished_history.uuid, route: 'moving_page')
+        expect(find('a', text: 'やめる')['data-turbo-method']).to eq 'delete'
+      end
+    end
+  end
+end

--- a/spec/system/search/goals_spec.rb
+++ b/spec/system/search/goals_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'Search::Goals' do
   let(:departure) { create(:departure) }
-  let(:destination) { create(:destination, departure: departure, user: departure.user) }
-  let(:not_finished_history) { create(:history, :not_finished, destination: destination, user: destination.user) }
+  let(:destination) { create(:destination, departure:, user: departure.user) }
+  let(:not_finished_history) { create(:history, :not_finished, destination:, user: destination.user) }
 
   describe 'Page' do
     context 'スタートし、ゴールページに遷移する' do

--- a/spec/system/search/goals_spec.rb
+++ b/spec/system/search/goals_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe 'Search::Goals' do
       end
 
       it '共通レイアウトが正常に表示されている' do
-        verify_user_layout
+        expect(nav_search_icon).to eq new_departure_path
+        expect(nav_folder_icon).to eq departures_path
+        expect(nav_user_icon).to eq profile_path
       end
     end
   end

--- a/spec/system/search/input_departures_spec.rb
+++ b/spec/system/search/input_departures_spec.rb
@@ -180,6 +180,7 @@ RSpec.describe 'Search::InputDepartures' do
         fill_in '名称', with: departure_form.name
         fill_in '住所', with: departure_form.address
         click_button '決定'
+        expect(page).to have_current_path new_departure_path
         expect(page).to have_content '位置情報の取得に失敗しました'
         expect(page).to have_field '名称', with: departure_form.name
         expect(page).to have_field '住所', with: departure_form.address

--- a/spec/system/search/input_departures_spec.rb
+++ b/spec/system/search/input_departures_spec.rb
@@ -26,7 +26,9 @@ RSpec.describe 'Search::InputDepartures' do
 
       it '共通レイアウトが正常に表示されている' do
         visit_new_departure_page(user)
-        verify_user_layout
+        expect(nav_search_icon).to eq new_departure_path
+        expect(nav_folder_icon).to eq departures_path
+        expect(nav_user_icon).to eq profile_path
       end
     end
   end

--- a/spec/system/search/input_departures_spec.rb
+++ b/spec/system/search/input_departures_spec.rb
@@ -152,21 +152,25 @@ RSpec.describe 'Search::InputDepartures' do
 
     context '名称を入力し、取得に失敗する' do
       it 'フォームから入力した名称が消えていない' do
-        name = 'a' * 51
-        fill_in '名称', with: name
-        fill_in '住所', with: departure_form.address
+        fill_in '名称', with: departure_form.name
         click_button '決定'
-        expect(page).to have_field '名称', with: name
+        expect(page).to have_field '名称', with: departure_form.name
       end
     end
 
     context '住所を入力し、取得に失敗する' do
       it 'フォームから入力した住所が消えていない' do
-        address = 'a' * 256
-        fill_in '名称', with: departure_form.name
-        fill_in '住所', with: address
+        fill_in '住所', with: departure_form.address
         click_button '決定'
-        expect(page).to have_field '住所', with: address
+        expect(page).to have_field '住所', with: departure_form.address
+      end
+    end
+
+    context 'チェックを入れ、作成に失敗する' do
+      it '変更したチェックボックスがもとに戻っていない' do
+        check '保存する'
+        click_button '決定'
+        expect(page).to have_checked_field '保存する'
       end
     end
   end

--- a/spec/system/search/input_departures_spec.rb
+++ b/spec/system/search/input_departures_spec.rb
@@ -173,7 +173,7 @@ RSpec.describe 'Search::InputDepartures' do
 
   describe 'Failure' do
     context '入力された住所が存在しないため、取得に失敗する' do
-      it 'エラーメッセージが表示され、編集状態に戻る' do
+      it 'エラーメッセージが表示され、出発地入力状態に戻る' do
         geocode_mock(false)
 
         visit_new_departure_page(user)

--- a/spec/system/search/input_departures_spec.rb
+++ b/spec/system/search/input_departures_spec.rb
@@ -23,6 +23,11 @@ RSpec.describe 'Search::InputDepartures' do
         expect(page).to have_field '住所', with: ''
         expect(page).to have_unchecked_field '保存する'
       end
+
+      it '共通レイアウトが正常に表示されている' do
+        visit_new_departure_page(user)
+        verify_user_layout
+      end
     end
   end
 

--- a/spec/system/search/input_destinations_spec.rb
+++ b/spec/system/search/input_destinations_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Search::InputDestinations' do
   let(:departure) { create(:departure, is_saved: true) }
   let(:nearby_result) { Settings.nearby_result.radius_1000.to_hash }
+  let(:destination_form) { build(:destination_form) }
 
   describe 'Page' do
     context '目的地を作成するページにアクセスする' do
@@ -28,124 +29,289 @@ RSpec.describe 'Search::InputDestinations' do
   end
 
   describe 'Edit' do
+    before do
+      nearby_mock(nearby_result)
+      visit_new_destination_page(departure)
+    end
+
     describe 'Validations' do
       context '正常な値を入力する' do
-        it '目的地の作成に成功し、スタートページに遷移する' do
+        before do
+          fill_in '名称', with: destination_form.name
+          fill_in 'コメント', with: destination_form.comment
+          check 'コメントを公開する'
+          fill_in '片道の距離', with: destination_form.distance
+        end
+
+        context '保存する' do
+          it '目的地の作成に成功し、スタートページに遷移する' do
+            check '保存する'
+            click_button '決定'
+            expect(page).to have_current_path new_history_path
+            expect(page).to have_content '目的地を保存しました'
+            expect(page).to have_content destination_form.name
+            expect(page).to have_content "#{destination_form.distance}m"
+            expect(page).to have_content nearby_result[:fixed][:address]
+            expect(page).to have_content destination_form.comment
+            expect(page).to have_content I18n.l(Destination.last.created_at, format: :short)
+            expect(page).to have_content departure.name
+          end
+        end
+
+        context '保存しない' do
+          it 'スタートページに遷移する' do
+            uncheck '保存する'
+            click_button '決定'
+            expect(page).to have_current_path new_history_path
+            expect(page).to have_content destination_form.name
+            expect(page).to have_content "#{destination_form.distance}m"
+            expect(page).to have_content nearby_result[:fixed][:address]
+            expect(page).not_to have_content destination_form.comment
+            expect(page).to have_content '未保存'
+            expect(page).to have_content departure.name
+          end
         end
       end
 
       describe '#name' do
+        before { fill_in '片道の距離', with: destination_form.distance }
+
         context '名称を空白にする' do
           it '目的地の作成に失敗し、作成ページに戻る' do
+            fill_in '名称', with: ''
+            click_button '決定'
+            expect(page).to have_current_path new_destination_path(destination: nearby_result[:variable][:uuid])
+            expect(page).to have_content '名称を入力してください'
+            expect(page).to have_content '入力情報に誤りがあります'
           end
         end
 
         context '名称を50文字入力する' do
           it '目的地の作成に成功し、スタートページに遷移する' do
+            name = 'a' * 50
+            fill_in '名称', with: name
+            click_button '決定'
+            expect(page).to have_current_path new_history_path
+            expect(page).to have_content name
           end
         end
 
         context '名称を51文字入力する' do
           it '目的地の作成に失敗し、作成ページに戻る' do
+            fill_in '名称', with: 'a' * 51
+            click_button '決定'
+            expect(page).to have_current_path new_destination_path(destination: nearby_result[:variable][:uuid])
+            expect(page).to have_content '名称は50文字以内で入力してください'
+            expect(page).to have_content '入力情報に誤りがあります'
           end
         end
       end
 
       describe '#comment' do
+        before do
+          fill_in '名称', with: destination_form.name
+          fill_in '片道の距離', with: destination_form.distance
+        end
+
         context 'コメントを空白にする' do
           it '目的地の作成に成功、スタートページに遷移する、公開・コメントアイコンは表示されない' do
+            fill_in 'コメント', with: ''
+            click_button '決定'
+            expect(page).to have_current_path new_history_path
+            expect(page).not_to have_css '.fa.fa-eye'
+            expect(page).not_to have_css '.fa.fa-eye-slash'
+            expect(page).not_to have_css '.fa.fa-commenting'
           end
         end
 
         context 'コメントを255文字入力する' do
           it '目的地の作成に成功、スタートページに遷移する、コメントアイコンが表示される' do
+            comment = 'a' * 255
+            fill_in 'コメント', with: comment
+            check '保存する'
+            click_button '決定'
+            expect(page).to have_current_path new_history_path
+            expect(page).to have_content comment
+            expect(page).to have_css '.fa.fa-commenting'
           end
         end
 
         context 'コメントを256文字入力する' do
           it '目的地の作成に失敗し、作成ページに戻る' do
+            fill_in 'コメント', with: 'a' * 256
+            click_button '決定'
+            expect(page).to have_current_path new_destination_path(destination: nearby_result[:variable][:uuid])
+            expect(page).to have_content 'コメントは255文字以内で入力してください'
+            expect(page).to have_content '入力情報に誤りがあります'
           end
         end
       end
 
       describe '#is_published_comment' do
+        before do
+          fill_in '名称', with: destination_form.name
+          fill_in '片道の距離', with: destination_form.distance
+          check '保存する'
+        end
+
         context 'コメントを公開・空白にする' do
           it '目的地の作成に成功、スタートページに遷移する、公開・コメントアイコンは表示されない' do
+            fill_in 'コメント', with: ''
+            check 'コメントを公開する'
+            click_button '決定'
+            expect(page).to have_current_path new_history_path
+            expect(page).not_to have_css '.fa.fa-eye'
+            expect(page).not_to have_css '.fa.fa-eye-slash'
+            expect(page).not_to have_css '.fa.fa-commenting'
           end
         end
 
         context 'コメントを非公開・空白にする' do
           it '目的地の作成に成功、スタートページに遷移する、公開・コメントアイコンは表示されない' do
+            fill_in 'コメント', with: ''
+            uncheck 'コメントを公開する'
+            click_button '決定'
+            expect(page).to have_current_path new_history_path
+            expect(page).not_to have_css '.fa.fa-eye'
+            expect(page).not_to have_css '.fa.fa-eye-slash'
+            expect(page).not_to have_css '.fa.fa-commenting'
           end
         end
 
         context 'コメントを公開・入力する' do
           it '目的地の作成に成功、スタートページに遷移する、公開・コメントアイコンが表示される' do
+            fill_in 'コメント', with: destination_form.comment
+            check 'コメントを公開する'
+            click_button '決定'
+            expect(page).to have_current_path new_history_path
+            expect(page).to have_content destination_form.comment
+            expect(page).to have_css '.fa.fa-eye'
+            expect(page).not_to have_css '.fa.fa-eye-slash'
+            expect(page).to have_css '.fa.fa-commenting'
           end
         end
 
         context 'コメントを非公開・入力する' do
           it '目的地の作成に成功、スタートページに遷移する、非公開・コメントアイコンが表示される' do
+            fill_in 'コメント', with: destination_form.comment
+            uncheck 'コメントを公開する'
+            click_button '決定'
+            expect(page).to have_current_path new_history_path
+            expect(page).to have_content destination_form.comment
+            expect(page).not_to have_css '.fa.fa-eye'
+            expect(page).to have_css '.fa.fa-eye-slash'
+            expect(page).to have_css '.fa.fa-commenting'
           end
         end
       end
 
       describe '#distance' do
+        before { fill_in '名称', with: destination_form.name }
+
         context '片道の距離を空白にする' do
           it '目的地の作成に失敗し、作成ページに戻る' do
+            fill_in '片道の距離', with: ''
+            click_button '決定'
+            expect(page).to have_current_path new_destination_path(destination: nearby_result[:variable][:uuid])
+            expect(page).to have_content '片道の距離を入力してください'
+            expect(page).to have_content '片道の距離は数値で入力してください'
+            expect(page).to have_content '入力情報に誤りがあります'
           end
         end
 
         context '片道の距離に0を入力する' do
           it '目的地の作成に失敗し、作成ページに戻る' do
+            fill_in '片道の距離', with: 0
+            click_button '決定'
+            expect(page).to have_current_path new_destination_path(destination: nearby_result[:variable][:uuid])
+            expect(page).to have_content '片道の距離は1m~21,097m以内に設定してください'
+            expect(page).to have_content '入力情報に誤りがあります'
           end
         end
 
         context '片道の距離に1を入力する' do
           it '目的地の作成に成功し、スタートページに遷移する' do
+            distance = 1
+            fill_in '片道の距離', with: distance
+            click_button '決定'
+            expect(page).to have_current_path new_history_path
+            expect(page).to have_content "#{distance}m"
           end
         end
 
         context '片道の距離に21,097を入力する' do
           it '目的地の作成に成功し、スタートページに遷移する' do
+            distance = 21_097
+            fill_in '片道の距離', with: distance
+            click_button '決定'
+            expect(page).to have_current_path new_history_path
+            expect(page).to have_content "#{distance}m"
           end
         end
 
         context '片道の距離に21,098を入力する' do
           it '目的地の作成に失敗し、作成ページに戻る' do
+            distance = 21_098
+            fill_in '片道の距離', with: distance
+            click_button '決定'
+            expect(page).to have_current_path new_destination_path(destination: nearby_result[:variable][:uuid])
+            expect(page).to have_content '片道の距離は1m~21,097m以内に設定してください'
+            expect(page).to have_content '入力情報に誤りがあります'
           end
         end
       end
     end
 
     describe 'Form' do
-      context '検索結果から目的地を選択し、作成するページにアクセスする' do
-        it 'フォームが表示され、初期値が入っている' do
-        end
+      before do
+        nearby_mock(nearby_result)
+        visit_new_destination_page(departure)
       end
 
-      context 'コメントから目的地を選択し、作成するページにアクセスする' do
-        it 'フォームが表示され、初期値が入っている' do
-        end
-      end
+      # context '検索結果から目的地を選択し、作成するページにアクセスする' do
+      #   it 'フォームが表示され、初期値が入っている' do
+      #   end
+      # end
+
+      # context 'コメントから目的地を選択し、作成するページにアクセスする' do
+      #   it 'フォームが表示され、初期値が入っている' do
+      #   end
+      # end
 
       context '名称を入力し、作成に失敗する' do
         it 'フォームから入力した名称が消えていない' do
+          name = 'a' * 51
+          fill_in '名称', with: name
+          click_button '決定'
+          expect(page).to have_field '名称', with: name
         end
       end
 
       context 'コメントを入力し、作成に失敗する' do
         it 'フォームから入力したコメントが消えていない' do
+          comment = 'a' * 256
+          fill_in 'コメント', with: comment
+          click_button '決定'
+          expect(page).to have_field 'コメント', with: comment
         end
       end
 
       context '作成に失敗する' do
         it '変更したチェックボックスがもとに戻っていない' do
+          check 'コメントを公開する'
+          check '保存する'
+          click_button '決定'
+          expect(page).to have_checked_field 'コメントを公開する'
+          expect(page).to have_checked_field '保存する'
         end
       end
 
       context '片道の距離を入力し、作成に失敗する' do
         it 'フォームから入力した片道の距離が消えていない' do
+          distance = 21_098
+          fill_in '片道の距離', with: distance
+          click_button '決定'
+          expect(page).to have_field '片道の距離', with: distance
         end
       end
     end

--- a/spec/system/search/input_destinations_spec.rb
+++ b/spec/system/search/input_destinations_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe 'Search::InputDestinations' do
       end
 
       it '共通レイアウトが正常に表示されている' do
-        verify_user_layout
+        expect(nav_search_icon).to eq new_departure_path
+        expect(nav_folder_icon).to eq departures_path
+        expect(nav_user_icon).to eq profile_path
       end
     end
   end

--- a/spec/system/search/input_destinations_spec.rb
+++ b/spec/system/search/input_destinations_spec.rb
@@ -12,6 +12,10 @@ RSpec.describe 'Search::InputDestinations' do
         nearby_mock(nearby_result)
         visit_new_destination_page(departure)
         expect(page).to have_current_path new_destination_path(destination: nearby_result[:variable][:uuid])
+        expect(page).to have_field '名称'
+        expect(page).to have_field 'コメント'
+        expect(page).to have_field '片道の距離'
+        expect(page).to have_unchecked_field '保存する'
       end
     end
   end

--- a/spec/system/search/input_destinations_spec.rb
+++ b/spec/system/search/input_destinations_spec.rb
@@ -8,14 +8,21 @@ RSpec.describe 'Search::InputDestinations' do
 
   describe 'Page' do
     context '目的地を作成するページにアクセスする' do
-      it '情報が正しく表示されている' do
+      before do
         nearby_mock(nearby_result)
         visit_new_destination_page(departure)
+      end
+
+      it '情報が正しく表示されている' do
         expect(page).to have_current_path new_destination_path(destination: nearby_result[:variable][:uuid])
         expect(page).to have_field '名称'
         expect(page).to have_field 'コメント'
         expect(page).to have_field '片道の距離'
         expect(page).to have_unchecked_field '保存する'
+      end
+
+      it '共通レイアウトが正常に表示されている' do
+        verify_user_layout
       end
     end
   end

--- a/spec/system/search/input_destinations_spec.rb
+++ b/spec/system/search/input_destinations_spec.rb
@@ -281,23 +281,21 @@ RSpec.describe 'Search::InputDestinations' do
 
       context '名称を入力し、作成に失敗する' do
         it 'フォームから入力した名称が消えていない' do
-          name = 'a' * 51
-          fill_in '名称', with: name
+          fill_in '名称', with: destination_form.name
           click_button '決定'
-          expect(page).to have_field '名称', with: name
+          expect(page).to have_field '名称', with: destination_form.name
         end
       end
 
       context 'コメントを入力し、作成に失敗する' do
         it 'フォームから入力したコメントが消えていない' do
-          comment = 'a' * 256
-          fill_in 'コメント', with: comment
+          fill_in 'コメント', with: destination_form.comment
           click_button '決定'
-          expect(page).to have_field 'コメント', with: comment
+          expect(page).to have_field 'コメント', with: destination_form.comment
         end
       end
 
-      context '作成に失敗する' do
+      context 'チェックを入れ、作成に失敗する' do
         it '変更したチェックボックスがもとに戻っていない' do
           check 'コメントを公開する'
           check '保存する'
@@ -309,10 +307,9 @@ RSpec.describe 'Search::InputDestinations' do
 
       context '片道の距離を入力し、作成に失敗する' do
         it 'フォームから入力した片道の距離が消えていない' do
-          distance = 21_098
-          fill_in '片道の距離', with: distance
+          fill_in '片道の距離', with: destination_form.distance
           click_button '決定'
-          expect(page).to have_field '片道の距離', with: distance
+          expect(page).to have_field '片道の距離', with: destination_form.distance
         end
       end
     end

--- a/spec/system/search/input_destinations_spec.rb
+++ b/spec/system/search/input_destinations_spec.rb
@@ -1,0 +1,155 @@
+require 'rails_helper'
+
+RSpec.describe 'Search::InputDestinations' do
+  let(:departure) { create(:departure, is_saved: true) }
+  let(:nearby_result) { Settings.nearby_result.radius_1000.to_hash }
+
+  describe 'Page' do
+    context '目的地を作成するページにアクセスする' do
+      it '情報が正しく表示されている' do
+        nearby_mock(nearby_result)
+        visit_new_destination_page(departure)
+        expect(page).to have_current_path new_destination_path(destination: nearby_result[:variable][:uuid])
+      end
+    end
+  end
+
+  describe 'Contents' do
+    context '目的地を作成するページにアクセスする' do
+      it 'リンク関連が正しく表示されている' do
+        nearby_mock(nearby_result)
+        visit_new_destination_page(departure)
+        expect(page).to have_button '決定'
+        expect(find('form')['action']).to be_include destinations_path
+        expect(find('form')['method']).to eq 'post'
+        expect(page).not_to have_field('_method', type: 'hidden')
+      end
+    end
+  end
+
+  describe 'Edit' do
+    describe 'Validations' do
+      context '正常な値を入力する' do
+        it '目的地の作成に成功し、スタートページに遷移する' do
+        end
+      end
+
+      describe '#name' do
+        context '名称を空白にする' do
+          it '目的地の作成に失敗し、作成ページに戻る' do
+          end
+        end
+
+        context '名称を50文字入力する' do
+          it '目的地の作成に成功し、スタートページに遷移する' do
+          end
+        end
+
+        context '名称を51文字入力する' do
+          it '目的地の作成に失敗し、作成ページに戻る' do
+          end
+        end
+      end
+
+      describe '#comment' do
+        context 'コメントを空白にする' do
+          it '目的地の作成に成功、スタートページに遷移する、公開・コメントアイコンは表示されない' do
+          end
+        end
+
+        context 'コメントを255文字入力する' do
+          it '目的地の作成に成功、スタートページに遷移する、コメントアイコンが表示される' do
+          end
+        end
+
+        context 'コメントを256文字入力する' do
+          it '目的地の作成に失敗し、作成ページに戻る' do
+          end
+        end
+      end
+
+      describe '#is_published_comment' do
+        context 'コメントを公開・空白にする' do
+          it '目的地の作成に成功、スタートページに遷移する、公開・コメントアイコンは表示されない' do
+          end
+        end
+
+        context 'コメントを非公開・空白にする' do
+          it '目的地の作成に成功、スタートページに遷移する、公開・コメントアイコンは表示されない' do
+          end
+        end
+
+        context 'コメントを公開・入力する' do
+          it '目的地の作成に成功、スタートページに遷移する、公開・コメントアイコンが表示される' do
+          end
+        end
+
+        context 'コメントを非公開・入力する' do
+          it '目的地の作成に成功、スタートページに遷移する、非公開・コメントアイコンが表示される' do
+          end
+        end
+      end
+
+      describe '#distance' do
+        context '片道の距離を空白にする' do
+          it '目的地の作成に失敗し、作成ページに戻る' do
+          end
+        end
+
+        context '片道の距離に0を入力する' do
+          it '目的地の作成に失敗し、作成ページに戻る' do
+          end
+        end
+
+        context '片道の距離に1を入力する' do
+          it '目的地の作成に成功し、スタートページに遷移する' do
+          end
+        end
+
+        context '片道の距離に21,097を入力する' do
+          it '目的地の作成に成功し、スタートページに遷移する' do
+          end
+        end
+
+        context '片道の距離に21,098を入力する' do
+          it '目的地の作成に失敗し、作成ページに戻る' do
+          end
+        end
+      end
+    end
+
+    describe 'Form' do
+      context '検索結果から目的地を選択し、作成するページにアクセスする' do
+        it 'フォームが表示され、初期値が入っている' do
+        end
+      end
+
+      context 'コメントから目的地を選択し、作成するページにアクセスする' do
+        it 'フォームが表示され、初期値が入っている' do
+        end
+      end
+
+      context '名称を入力し、作成に失敗する' do
+        it 'フォームから入力した名称が消えていない' do
+        end
+      end
+
+      context 'コメントを入力し、作成に失敗する' do
+        it 'フォームから入力したコメントが消えていない' do
+        end
+      end
+
+      context '作成に失敗する' do
+        it '変更したチェックボックスがもとに戻っていない' do
+        end
+      end
+
+      context '片道の距離を入力し、作成に失敗する' do
+        it 'フォームから入力した片道の距離が消えていない' do
+        end
+      end
+    end
+  end
+
+  # describe 'AutomaticDistanceInput'
+end

--- a/spec/system/search/input_terms_spec.rb
+++ b/spec/system/search/input_terms_spec.rb
@@ -116,7 +116,6 @@ RSpec.describe 'Search::InputTerms' do
       context '距離に1,000を入力する' do
         it '目的地の検索に成功し、一覧が表示される' do
           fill_in '距離(1000m~5000m)', with: 1_000
-          select 'カフェ', from: '種類'
           click_button '検索'
           sleep(0.1)
           expect(page).to have_current_path searches_path
@@ -178,7 +177,7 @@ RSpec.describe 'Search::InputTerms' do
         select 'カフェ', from: '種類'
         click_button '検索'
         expect(page).to have_current_path new_search_path(departure: departure.uuid)
-        expect(page).to have_select('種類', selected: 'カフェ')
+        expect(page).to have_select '種類', selected: 'カフェ'
       end
     end
   end
@@ -190,9 +189,12 @@ RSpec.describe 'Search::InputTerms' do
         visit_input_terms_page(departure)
 
         fill_in '距離(1000m~5000m)', with: 1000
+        select 'カフェ', from: '種類'
         click_button '検索'
         expect(page).to have_current_path new_search_path(departure: departure.uuid)
         expect(page).to have_content '目的地が見つかりませんでした'
+        expect(page).to have_field '距離(1000m~5000m)', with: 1000
+        expect(page).to have_select '種類', selected: 'カフェ'
       end
     end
   end

--- a/spec/system/search/input_terms_spec.rb
+++ b/spec/system/search/input_terms_spec.rb
@@ -19,6 +19,11 @@ RSpec.describe 'Search::InputTerms' do
         expect(page).to have_field '距離(1000m~5000m)', with: ''
         expect(page).to have_select '種類', selected: 'コンビニエンスストア'
       end
+
+      it '共通レイアウトが正常に表示されている' do
+        visit_input_terms_page(departure)
+        verify_user_layout
+      end
     end
   end
 

--- a/spec/system/search/input_terms_spec.rb
+++ b/spec/system/search/input_terms_spec.rb
@@ -22,7 +22,9 @@ RSpec.describe 'Search::InputTerms' do
 
       it '共通レイアウトが正常に表示されている' do
         visit_input_terms_page(departure)
-        verify_user_layout
+        expect(nav_search_icon).to eq new_departure_path
+        expect(nav_folder_icon).to eq departures_path
+        expect(nav_user_icon).to eq profile_path
       end
     end
   end

--- a/spec/system/search/input_terms_spec.rb
+++ b/spec/system/search/input_terms_spec.rb
@@ -27,7 +27,6 @@ RSpec.describe 'Search::InputTerms' do
       before { visit_input_terms_page(departure) }
 
       it '情報が正しく表示されている' do
-        expect(page).to have_current_path new_search_path(departure: departure.uuid)
         expect(page).to have_content departure.name
         expect(page).to have_content departure.address
         expect(page).to have_content I18n.l(departure.created_at, format: :short)

--- a/spec/system/search/results_spec.rb
+++ b/spec/system/search/results_spec.rb
@@ -20,7 +20,9 @@ RSpec.describe 'Search::Results' do
       it '共通レイアウトが正常に表示されている' do
         nearby_mock(nearby_result)
         visit_search_results_page(departure)
-        verify_user_layout
+        expect(nav_search_icon).to eq new_departure_path
+        expect(nav_folder_icon).to eq departures_path
+        expect(nav_user_icon).to eq profile_path
       end
     end
   end

--- a/spec/system/search/results_spec.rb
+++ b/spec/system/search/results_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe 'Search::Results' do
         end
 
         it '情報が正しく表示されている' do
-          expect(page).to have_current_path searches_path
           expect(page).to have_content nearby_result[:variable][:name]
           expect(page).to have_content nearby_result[:fixed][:address]
         end
@@ -55,7 +54,6 @@ RSpec.describe 'Search::Results' do
         end
 
         it '情報が正しく表示されている' do
-          expect(page).to have_current_path searches_path
           expect(page).to have_content published_comment_destination.name
           expect(page).to have_content published_comment_destination.address
           expect(page).to have_content published_comment_destination.comment

--- a/spec/system/search/results_spec.rb
+++ b/spec/system/search/results_spec.rb
@@ -16,6 +16,12 @@ RSpec.describe 'Search::Results' do
         expect(page).to have_content 'コメント'
         expect(page).to have_content '保存済み'
       end
+
+      it '共通レイアウトが正常に表示されている' do
+        nearby_mock(nearby_result)
+        visit_search_results_page(departure)
+        verify_user_layout
+      end
     end
   end
 

--- a/spec/system/search/select_departures_spec.rb
+++ b/spec/system/search/select_departures_spec.rb
@@ -20,6 +20,16 @@ RSpec.describe 'Search::SelectDepartures' do
         expect(page).to have_content '履歴'
       end
     end
+
+    context '保存済み出発地のページにアクセスし、編集状態にする' do
+      it '情報が正しく表示されている' do
+        visit_select_saved_departures_page(departure)
+        find('.fa.fa-chevron-down').click
+        click_link '編集'
+        expect(page).to have_field '名称'
+        expect(page).to have_field '住所'
+      end
+    end
   end
 
   describe 'Saved' do

--- a/spec/system/search/select_departures_spec.rb
+++ b/spec/system/search/select_departures_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe 'Search::SelectDepartures' do
         before { visit_select_saved_departures_page(departure) }
 
         it '情報が正しく表示されている' do
-          expect(page).to have_current_path new_departure_path
           expect(page).to have_content departure.name
           expect(page).to have_content departure.address
           expect(page).to have_content I18n.l(departure.created_at, format: :short)
@@ -265,7 +264,6 @@ RSpec.describe 'Search::SelectDepartures' do
         before { visit_select_history_departure_page(history.departure) }
 
         it '情報が正しく表示されている' do
-          expect(page).to have_current_path new_departure_path
           expect(page).to have_content history.departure.name
           expect(page).to have_content history.departure.address
           expect(page).to have_content I18n.l(history.start_time, format: :short)

--- a/spec/system/search/select_departures_spec.rb
+++ b/spec/system/search/select_departures_spec.rb
@@ -9,6 +9,8 @@ RSpec.describe 'Search::SelectDepartures' do
 
   describe 'Page' do
     context '出発地を入力するページにアクセスする' do
+      before { visit_select_saved_departures_page(departure) }
+
       it '情報が正しく表示されている' do
         login(user)
         sleep(0.1)
@@ -18,6 +20,10 @@ RSpec.describe 'Search::SelectDepartures' do
         expect(page).to have_content '入力'
         expect(page).to have_content '保存'
         expect(page).to have_content '履歴'
+      end
+
+      it '共通レイアウトが正常に表示されている' do
+        verify_user_layout
       end
     end
 

--- a/spec/system/search/select_departures_spec.rb
+++ b/spec/system/search/select_departures_spec.rb
@@ -242,6 +242,21 @@ RSpec.describe 'Search::SelectDepartures' do
         end
       end
     end
+
+    describe 'Database' do
+      context '出発地を削除する' do
+        it '出発地が保存しないに変更される' do
+          visit_select_saved_departures_page(departure)
+          find('.fa.fa-chevron-down').click
+          sleep(0.1)
+          page.accept_confirm("保存済みから削除します\nよろしいですか?") do
+            click_link '削除'
+          end
+          sleep(0.1)
+          expect(Departure.find_by(id: departure.id).is_saved).to be_falsey
+        end
+      end
+    end
   end
 
   describe 'History' do

--- a/spec/system/search/select_departures_spec.rb
+++ b/spec/system/search/select_departures_spec.rb
@@ -23,7 +23,9 @@ RSpec.describe 'Search::SelectDepartures' do
       end
 
       it '共通レイアウトが正常に表示されている' do
-        verify_user_layout
+        expect(nav_search_icon).to eq new_departure_path
+        expect(nav_folder_icon).to eq departures_path
+        expect(nav_user_icon).to eq profile_path
       end
     end
 

--- a/spec/system/search/show_hitories_spec.rb
+++ b/spec/system/search/show_hitories_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe 'Search::ShowHitories' do
       end
 
       it '共通レイアウトが正常に表示されている' do
-        verify_user_layout
+        expect(nav_search_icon).to eq new_departure_path
+        expect(nav_folder_icon).to eq departures_path
+        expect(nav_user_icon).to eq profile_path
       end
     end
 

--- a/spec/system/search/show_hitories_spec.rb
+++ b/spec/system/search/show_hitories_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe 'Search::ShowHitories' do
+  let(:departure) { create(:departure) }
+  let(:destination) { create(:destination, departure: departure, user: departure.user) }
+  let(:history) { create(:history, destination: destination, user: destination.user) }
+
+  describe 'Page' do
+    context '履歴詳細ページに遷移する' do
+      it '情報が正しく表示されている' do
+        visit_show_history_page(history)
+        expect(page).to have_current_path history_path(history.uuid)
+      end
+    end
+  end
+
+  describe 'Contents' do
+    context '履歴詳細ページに遷移する' do
+      before { visit_show_history_page(history) }
+
+      it 'コンテンツが正しく表示されている' do
+        expect(page).to have_content history.destination.name
+        expect(page).to have_content "#{history.moving_distance}m"
+        expect(page).to have_content history.destination.address
+        expect(page).to have_content "START: #{I18n.l(history.start_time, format: :short)}"
+        expect(page).to have_content "GOAL: #{I18n.l(history.end_time, format: :short)}"
+        expect(page).to have_content history.departure.name
+      end
+
+      it 'リンク関連が正しく表示されている' do
+        expect(page).to have_link 'ユーザーページに戻る', href: profile_path
+        find('.fa.fa-chevron-down').click
+        expect(page).to have_link '編集', href: edit_history_path(history.uuid, route: 'goal_page')
+        expect(page).to have_link '削除', href: history_path(history.uuid, route: 'goal_page')
+        expect(find('a', text: '削除')['data-turbo-method']).to eq 'delete'
+      end
+    end
+  end
+end

--- a/spec/system/search/show_hitories_spec.rb
+++ b/spec/system/search/show_hitories_spec.rb
@@ -7,9 +7,14 @@ RSpec.describe 'Search::ShowHitories' do
 
   describe 'Page' do
     context '履歴詳細ページに遷移する' do
+      before { visit_show_history_page(history) }
+
       it '情報が正しく表示されている' do
-        visit_show_history_page(history)
         expect(page).to have_current_path history_path(history.uuid)
+      end
+
+      it '共通レイアウトが正常に表示されている' do
+        verify_user_layout
       end
     end
 

--- a/spec/system/search/show_hitories_spec.rb
+++ b/spec/system/search/show_hitories_spec.rb
@@ -36,4 +36,254 @@ RSpec.describe 'Search::ShowHitories' do
       end
     end
   end
+
+  describe 'Edit' do
+    let(:build_another_history) { build(:history, :another, :commented) }
+
+    before do
+      visit_show_history_page(history)
+      find('.fa.fa-chevron-down').click
+      click_link('編集')
+      sleep(0.1)
+    end
+
+    describe 'Validations' do
+      context '正常な値を入力する' do
+        it '履歴の更新に成功し、一覧が表示される' do
+          fill_in '開始時刻', with: build_another_history.start_time
+          fill_in '終了時刻', with: build_another_history.end_time
+          fill_in 'コメント', with: build_another_history.comment
+          fill_in '移動距離', with: build_another_history.moving_distance
+          click_button '更新'
+          expect(page).to have_content '履歴を更新しました'
+          expect(page).not_to have_css '.fa.fa-eye'
+          expect(page).to have_css '.fa.fa-eye-slash'
+          expect(page).to have_css '.fa.fa-commenting'
+          expect(page).to have_content build_another_history.comment
+          expect(page).to have_content "#{build_another_history.moving_distance}m"
+          expect(page).to have_content I18n.l(build_another_history.start_time, format: :short)
+          expect(page).to have_content I18n.l(build_another_history.end_time, format: :short)
+        end
+      end
+
+      describe '#start_time' do
+        context '開始時刻を空白にする' do
+          it '履歴の更新に失敗し、編集状態に戻る' do
+            fill_in '開始時刻', with: ''
+            click_button '更新'
+            expect(page).to have_content '開始時刻を入力してください'
+            expect(page).to have_content '入力情報に誤りがあります'
+          end
+        end
+      end
+
+      describe '#end_time' do
+        context '終了時刻を空白にする' do
+          it '履歴の更新に失敗し、編集状態に戻る' do
+            fill_in '終了時刻', with: ''
+            click_button '更新'
+            expect(page).to have_content '終了時刻を入力してください'
+            expect(page).to have_content '入力情報に誤りがあります'
+          end
+        end
+
+        context '終了時刻を開始時刻より遅い時刻にする' do
+          it '履歴の更新に失敗し、編集状態に戻る' do
+            fill_in '開始時刻', with: build_another_history.end_time
+            fill_in '終了時刻', with: build_another_history.start_time
+            click_button '更新'
+            expect(page).to have_content 'は開始時刻より遅い時間にしてください'
+            expect(page).to have_content '入力情報に誤りがあります'
+          end
+        end
+      end
+
+      describe '#comment' do
+        context 'コメントを空白にする' do
+          it '履歴の更新に成功、一覧が表示される、非公開・コメントアイコンは表示されない' do
+            fill_in 'コメント', with: ''
+            click_button '更新'
+            expect(page).to have_content '履歴を更新しました'
+            expect(page).not_to have_css '.fa.fa-eye-slash'
+            expect(page).not_to have_css '.fa.fa-commenting'
+          end
+        end
+
+        context 'コメントを255文字入力する' do
+          it '履歴の更新に成功、一覧が表示される、非公開・コメントアイコンが表示される' do
+            comment = 'a' * 255
+            fill_in 'コメント', with: comment
+            click_button '更新'
+            expect(page).to have_content '履歴を更新しました'
+            expect(page).not_to have_css '.fa.fa-eye'
+            expect(page).to have_css '.fa.fa-eye-slash'
+            expect(page).to have_css '.fa.fa-commenting'
+            expect(page).to have_content comment
+          end
+        end
+
+        context 'コメントを256文字入力する' do
+          it '履歴の更新に失敗し、編集状態に戻る' do
+            fill_in 'コメント', with: 'a' * 256
+            click_button '更新'
+            expect(page).to have_content 'コメントは255文字以内で入力してください'
+            expect(page).to have_content '入力情報に誤りがあります'
+          end
+        end
+      end
+
+      describe '#moving_distance' do
+        context '移動距離を空白にする' do
+          it '保存済み目的地の更新に失敗し、編集状態に戻る' do
+            fill_in '移動距離', with: ''
+            click_button '更新'
+            expect(page).to have_content '移動距離を入力してください'
+            expect(page).to have_content '移動距離は数値で入力してください'
+            expect(page).to have_content '入力情報に誤りがあります'
+          end
+        end
+
+        context '移動距離に0を入力する' do
+          it '保存済み目的地の更新に失敗し、編集状態に戻る' do
+            fill_in '移動距離', with: 0
+            click_button '更新'
+            expect(page).to have_content '移動距離は1m~42,195m以内に設定してください'
+            expect(page).to have_content '入力情報に誤りがあります'
+          end
+        end
+
+        context '移動距離に1を入力する' do
+          it '保存済み目的地の更新に成功し、一覧が表示される' do
+            fill_in '移動距離', with: 1
+            click_button '更新'
+            expect(page).to have_content '履歴を更新しました'
+            expect(page).to have_content '1m'
+          end
+        end
+
+        context '移動距離に42_195を入力する' do
+          it '保存済み目的地の更新に成功し、一覧が表示される' do
+            fill_in '移動距離', with: 42_195
+            click_button '更新'
+            expect(page).to have_content '履歴を更新しました'
+            expect(page).to have_content '42195m'
+          end
+        end
+
+        context '移動距離に42_196を入力する' do
+          it '保存済み目的地の更新に失敗し、編集状態に戻る' do
+            fill_in '移動距離', with: 42_196
+            click_button '更新'
+            expect(page).to have_content '移動距離は1m~42,195m以内に設定してください'
+            expect(page).to have_content '入力情報に誤りがあります'
+          end
+        end
+      end
+    end
+
+    describe 'Form' do
+      context '編集フォームを表示させる' do
+        it 'フォームが表示され、初期値が入っている' do
+          expect(page).to have_field '開始時刻', with: history.start_time.strftime('%Y-%m-%dT%H:%M')
+          expect(page).to have_field '終了時刻', with: history.end_time.strftime('%Y-%m-%dT%H:%M')
+          expect(page).to have_field 'コメント', with: history.comment
+          expect(page).to have_field '移動距離', with: history.moving_distance
+        end
+      end
+
+      context '開始時刻を入力し、更新に失敗する' do
+        it 'フォームから入力した開始時刻が消えていない' do
+          fill_in '開始時刻', with: build_another_history.end_time
+          fill_in '終了時刻', with: build_another_history.start_time
+          click_button '更新'
+          expect(page).to have_field '開始時刻', with: build_another_history.end_time.strftime('%Y-%m-%dT%H:%M')
+        end
+      end
+
+      context '終了時刻を入力し、更新に失敗する' do
+        it 'フォームから入力した終了時刻が消えていない' do
+          fill_in '開始時刻', with: build_another_history.end_time
+          fill_in '終了時刻', with: build_another_history.start_time
+          click_button '更新'
+          expect(page).to have_field '終了時刻', with: build_another_history.start_time.strftime('%Y-%m-%dT%H:%M')
+        end
+      end
+
+      context 'コメントを入力し、更新に失敗する' do
+        it 'フォームから入力したコメントが消えていない' do
+          comment = 'a' * 256
+          fill_in 'コメント', with: comment
+          click_button '更新'
+          expect(page).to have_field 'コメント', with: comment
+        end
+      end
+
+      context '移動距離を入力し、更新に失敗する' do
+        it 'フォームから入力した移動距離が消えていない' do
+          distance = 0
+          fill_in '移動距離', with: distance
+          click_button '更新'
+          expect(page).to have_field '移動距離', with: distance
+        end
+      end
+    end
+
+    describe 'Cancel' do
+      context '編集フォームを表示させた後、取り消しボタンを押す' do
+        it '履歴が適切に表示される' do
+          click_link '取消'
+          expect(page).to have_content history.destination.name
+        end
+      end
+
+      context '編集フォームを表示させ、内容を変えた後、取り消しボタンを押す' do
+        it '更新されていない履歴が適切に表示される' do
+          fill_in '開始時刻', with: build_another_history.start_time
+          fill_in '終了時刻', with: build_another_history.end_time
+          fill_in 'コメント', with: build_another_history.comment
+          fill_in '移動距離', with: build_another_history.moving_distance
+          click_link '取消'
+          expect(page).to have_content "#{history.moving_distance}m"
+          expect(page).to have_content I18n.l(history.start_time, format: :short)
+          expect(page).to have_content I18n.l(history.end_time, format: :short)
+
+          expect(page).not_to have_css '.fa.fa-eye'
+          expect(page).not_to have_css '.fa.fa-eye-slash'
+          expect(page).not_to have_css '.fa.fa-commenting'
+          expect(page).not_to have_content build_another_history.comment
+          expect(page).not_to have_content "#{build_another_history.moving_distance}m"
+          expect(page).not_to have_content I18n.l(build_another_history.start_time, format: :short)
+          expect(page).not_to have_content I18n.l(build_another_history.end_time, format: :short)
+        end
+      end
+    end
+  end
+
+  describe 'Destroy' do
+    before do
+      visit_show_history_page(history)
+      find('.fa.fa-chevron-down').click
+    end
+
+    context '削除ボタンをクリックする' do
+      it '正常に削除される' do
+        page.accept_confirm("履歴から削除します\nよろしいですか?") do
+          click_link '削除'
+        end
+        expect(page).to have_content '履歴を削除しました'
+        expect(page).to have_current_path new_history_path(destination: history.destination.uuid)
+      end
+    end
+  end
+
+  describe 'Profile' do
+    context 'ユーザーページに戻るをクリックする' do
+      it 'ユーザーページに遷移する' do
+        visit_show_history_page(history)
+        click_link 'ユーザーページに戻る'
+        expect(page).to have_current_path profile_path
+        expect(page).to have_content history.user.name
+      end
+    end
+  end
 end

--- a/spec/system/search/show_hitories_spec.rb
+++ b/spec/system/search/show_hitories_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe 'Search::ShowHitories' do
   let(:departure) { create(:departure) }
-  let(:destination) { create(:destination, departure: departure, user: departure.user) }
-  let(:history) { create(:history, destination: destination, user: destination.user) }
+  let(:destination) { create(:destination, departure:, user: departure.user) }
+  let(:history) { create(:history, destination:, user: destination.user) }
 
   describe 'Page' do
     context '履歴詳細ページに遷移する' do

--- a/spec/system/search/show_hitories_spec.rb
+++ b/spec/system/search/show_hitories_spec.rb
@@ -12,6 +12,19 @@ RSpec.describe 'Search::ShowHitories' do
         expect(page).to have_current_path history_path(history.uuid)
       end
     end
+
+    context '履歴詳細ページに遷移し、編集状態にする' do
+      it '情報が正しく表示されている' do
+        visit_show_history_page(history)
+        find('.fa.fa-chevron-down').click
+        click_link('編集')
+        sleep(0.1)
+        expect(page).to have_field '開始時刻'
+        expect(page).to have_field '終了時刻'
+        expect(page).to have_field 'コメント', with: ''
+        expect(page).to have_field '移動距離'
+      end
+    end
   end
 
   describe 'Contents' do

--- a/spec/system/search/starts_spec.rb
+++ b/spec/system/search/starts_spec.rb
@@ -19,7 +19,9 @@ RSpec.describe 'Search::Starts' do
       end
 
       it '共通レイアウトが正常に表示されている' do
-        verify_user_layout
+        expect(nav_search_icon).to eq new_departure_path
+        expect(nav_folder_icon).to eq departures_path
+        expect(nav_user_icon).to eq profile_path
       end
     end
 

--- a/spec/system/search/starts_spec.rb
+++ b/spec/system/search/starts_spec.rb
@@ -8,11 +8,18 @@ RSpec.describe 'Search::Starts' do
   let(:destination_form) { build(:destination_form) }
 
   describe 'Page' do
+    before do
+      nearby_mock(nearby_result)
+      visit_start_page_from_new(departure)
+    end
+
     context '目的地を作成するページから、スタートするページにアクセスする' do
       it '情報が正しく表示されている' do
-        nearby_mock(nearby_result)
-        visit_start_page_from_new(departure)
         expect(page).to have_current_path new_history_path
+      end
+
+      it '共通レイアウトが正常に表示されている' do
+        verify_user_layout
       end
     end
 

--- a/spec/system/search/starts_spec.rb
+++ b/spec/system/search/starts_spec.rb
@@ -392,4 +392,55 @@ RSpec.describe 'Search::Starts' do
       end
     end
   end
+
+  describe 'Destroy' do
+    before do
+      nearby_mock(nearby_result)
+      visit_new_destination_page(departure)
+      fill_in '名称', with: 'destination-name'
+      fill_in '片道の距離', with: 1000
+      check '保存する'
+      click_button '決定'
+      sleep(0.1)
+      find('.fa.fa-chevron-down').click
+    end
+
+    context '削除ボタンをクリックする' do
+      it '目的地が削除され、検索結果ページに遷移する' do
+        page.accept_confirm("保存を取り消します\nよろしいですか?") do
+          click_link '削除'
+        end
+        expect(page).to have_content '保存済みから削除しました'
+        expect(page).to have_current_path searches_path
+      end
+    end
+  end
+
+  describe 'Start' do
+    before { visit_start_page_from_saved(destination) }
+
+    context 'スタート（片道）をクリックする' do
+      it 'スタートし、ゴールページに遷移する' do
+        click_link 'スタート(片道)'
+        sleep(0.1)
+        expect(page).to have_content 'スタートしました(片道)'
+        expect(page).to have_current_path history_path(History.last.uuid)
+        expect(page).to have_content "#{destination.distance}m"
+        expect(page).not_to have_link 'スタート(片道)'
+        expect(page).not_to have_link 'スタート(往復)'
+      end
+    end
+
+    context 'スタート（往復）をクリックする' do
+      it 'スタートし、ゴールページに遷移する' do
+        click_link 'スタート(往復)'
+        sleep(0.1)
+        expect(page).to have_content 'スタートしました(往復)'
+        expect(page).to have_current_path history_path(History.last.uuid)
+        expect(page).to have_content "#{destination.distance * 2}m"
+        expect(page).not_to have_link 'スタート(片道)'
+        expect(page).not_to have_link 'スタート(往復)'
+      end
+    end
+  end
 end

--- a/spec/system/search/starts_spec.rb
+++ b/spec/system/search/starts_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe 'Search::Starts' do
   let(:departure) { create(:departure, is_saved: true) }
   let(:destination) { create(:destination, is_saved: true) }
+  let(:user) { create(:user) }
   let(:nearby_result) { Settings.nearby_result.radius_1000.to_hash }
   let(:destination_form) { build(:destination_form) }
 
@@ -440,6 +441,30 @@ RSpec.describe 'Search::Starts' do
         expect(page).to have_content "#{destination.distance * 2}m"
         expect(page).not_to have_link 'スタート(片道)'
         expect(page).not_to have_link 'スタート(往復)'
+      end
+    end
+  end
+
+  describe 'Database' do
+    context '出発地・目的地を保存した状態でスタートする' do
+      it '履歴が作成される' do
+        visit_start_page_from_saved(destination)
+        click_link 'スタート(片道)'
+        sleep(0.1)
+        expect(History.count).to eq 1
+      end
+    end
+
+    context '出発地・目的地を保存していない状態でスタートする' do
+      it '出発地・目的地・履歴が作成される' do
+        visit_start_page_from_not_saved(user)
+        click_link 'スタート(片道)'
+        sleep(0.1)
+        expect(Departure.count).to eq 1
+        expect(Departure.first.is_saved).to be_falsey
+        expect(Destination.count).to eq 1
+        expect(Destination.first.is_saved).to be_falsey
+        expect(History.count).to eq 1
       end
     end
   end

--- a/spec/system/search/starts_spec.rb
+++ b/spec/system/search/starts_spec.rb
@@ -47,6 +47,14 @@ RSpec.describe 'Search::Starts' do
         expect(find('a', text: 'スタート(片道)')['data-turbo-method']).to eq 'post'
         expect(page).to have_link 'スタート(往復)', href: histories_path(course: 'round_trip')
         expect(find('a', text: 'スタート(往復)')['data-turbo-method']).to eq 'post'
+        find('.fa.fa-chevron-down').click
+        expect(page).to have_link '編集', href: edit_destination_path(destination.uuid, route: 'start_page')
+        expect(page).to have_link '削除', href: destination_path(destination.uuid, route: 'start_page')
+        click_link '編集'
+        expect(page).to have_link '取消', href: destination_path(destination.uuid, route: 'start_page')
+        expect(page).to have_button '更新'
+        expect(find('form')['action']).to be_include destination_path(destination.uuid, route: 'start_page')
+        expect(find('input[name="_method"]', visible: false)['value']).to eq 'patch'
       end
     end
 
@@ -66,6 +74,7 @@ RSpec.describe 'Search::Starts' do
         expect(find('a', text: 'スタート(片道)')['data-turbo-method']).to eq 'post'
         expect(page).to have_link 'スタート(往復)', href: histories_path(course: 'round_trip')
         expect(find('a', text: 'スタート(往復)')['data-turbo-method']).to eq 'post'
+        expect(page).not_to have_css '.fa.fa-chevron-down'
       end
     end
 
@@ -103,6 +112,283 @@ RSpec.describe 'Search::Starts' do
         expect(page).to have_current_path new_history_path(destination: not_published_comment_destination.uuid)
         expect(page).not_to have_css '.fa.fa-eye'
         expect(page).to have_css '.fa.fa-eye-slash'
+      end
+    end
+  end
+
+  describe 'Edit' do
+    describe 'Validations' do
+      before do
+        visit_start_page_from_saved(destination)
+        sleep(0.1)
+        find('.fa.fa-chevron-down').click
+        click_link('編集')
+      end
+
+      context '正常な値を入力する' do
+        it '目的地の編集に成功し、スタートページに遷移する' do
+          fill_in '名称', with: destination_form.name
+          fill_in 'コメント', with: destination_form.comment
+          check 'コメントを公開する'
+          fill_in '片道の距離', with: destination_form.distance
+          click_button '更新'
+          expect(page).to have_current_path new_history_path(destination: destination.uuid)
+          expect(page).to have_content '目的地を更新しました'
+          expect(page).to have_content destination_form.name
+          expect(page).to have_content "#{destination_form.distance}m"
+          expect(page).to have_content destination.address
+          expect(page).to have_content destination_form.comment
+          expect(page).to have_content I18n.l(Destination.last.created_at, format: :short)
+          expect(page).to have_content destination.departure.name
+        end
+      end
+
+      describe '#name' do
+        context '名称を空白にする' do
+          it '目的地の編集に失敗し、編集状態に戻る' do
+            fill_in '名称', with: ''
+            click_button '更新'
+            expect(page).to have_content '名称を入力してください'
+            expect(page).to have_content '入力情報に誤りがあります'
+          end
+        end
+
+        context '名称を50文字入力する' do
+          it '目的地の編集に成功し、スタートページに遷移する' do
+            name = 'a' * 50
+            fill_in '名称', with: name
+            click_button '更新'
+            expect(page).to have_content name
+          end
+        end
+
+        context '名称を51文字入力する' do
+          it '目的地の編集に失敗し、編集状態に戻る' do
+            fill_in '名称', with: 'a' * 51
+            click_button '更新'
+            expect(page).to have_content '名称は50文字以内で入力してください'
+            expect(page).to have_content '入力情報に誤りがあります'
+          end
+        end
+      end
+
+      describe '#comment' do
+        context 'コメントを空白にする' do
+          it '目的地の編集に成功、スタートページに遷移する、公開・コメントアイコンは表示されない' do
+            fill_in 'コメント', with: ''
+            click_button '更新'
+            expect(page).not_to have_css '.fa.fa-eye'
+            expect(page).not_to have_css '.fa.fa-eye-slash'
+            expect(page).not_to have_css '.fa.fa-commenting'
+          end
+        end
+
+        context 'コメントを255文字入力する' do
+          it '目的地の編集に成功、スタートページに遷移する、コメントアイコンが表示される' do
+            comment = 'a' * 255
+            fill_in 'コメント', with: comment
+            click_button '更新'
+            expect(page).to have_content comment
+            expect(page).to have_css '.fa.fa-commenting'
+          end
+        end
+
+        context 'コメントを256文字入力する' do
+          it '目的地の編集に失敗し、編集状態に戻る' do
+            fill_in 'コメント', with: 'a' * 256
+            click_button '更新'
+            expect(page).to have_content 'コメントは255文字以内で入力してください'
+            expect(page).to have_content '入力情報に誤りがあります'
+          end
+        end
+      end
+
+      describe '#is_published_comment' do
+        context 'コメントを公開・空白にする' do
+          it '目的地の編集に成功、スタートページに遷移する、公開・コメントアイコンは表示されない' do
+            fill_in 'コメント', with: ''
+            check 'コメントを公開する'
+            click_button '更新'
+            expect(page).not_to have_css '.fa.fa-eye'
+            expect(page).not_to have_css '.fa.fa-eye-slash'
+            expect(page).not_to have_css '.fa.fa-commenting'
+          end
+        end
+
+        context 'コメントを非公開・空白にする' do
+          it '目的地の編集に成功、スタートページに遷移する、公開・コメントアイコンは表示されない' do
+            fill_in 'コメント', with: ''
+            uncheck 'コメントを公開する'
+            click_button '更新'
+            expect(page).not_to have_css '.fa.fa-eye'
+            expect(page).not_to have_css '.fa.fa-eye-slash'
+            expect(page).not_to have_css '.fa.fa-commenting'
+          end
+        end
+
+        context 'コメントを公開・入力する' do
+          it '目的地の編集に成功、スタートページに遷移する、公開・コメントアイコンが表示される' do
+            fill_in 'コメント', with: destination_form.comment
+            check 'コメントを公開する'
+            click_button '更新'
+            expect(page).to have_content destination_form.comment
+            expect(page).to have_css '.fa.fa-eye'
+            expect(page).not_to have_css '.fa.fa-eye-slash'
+            expect(page).to have_css '.fa.fa-commenting'
+          end
+        end
+
+        context 'コメントを非公開・入力する' do
+          it '目的地の編集に成功、スタートページに遷移する、非公開・コメントアイコンが表示される' do
+            fill_in 'コメント', with: destination_form.comment
+            uncheck 'コメントを公開する'
+            click_button '更新'
+            expect(page).to have_content destination_form.comment
+            expect(page).not_to have_css '.fa.fa-eye'
+            expect(page).to have_css '.fa.fa-eye-slash'
+            expect(page).to have_css '.fa.fa-commenting'
+          end
+        end
+      end
+
+      describe '#distance' do
+        context '片道の距離を空白にする' do
+          it '目的地の編集に失敗し、編集状態に戻る' do
+            fill_in '片道の距離', with: ''
+            click_button '更新'
+            expect(page).to have_content '片道の距離を入力してください'
+            expect(page).to have_content '片道の距離は数値で入力してください'
+            expect(page).to have_content '入力情報に誤りがあります'
+          end
+        end
+
+        context '片道の距離に0を入力する' do
+          it '目的地の編集に失敗し、編集状態に戻る' do
+            fill_in '片道の距離', with: 0
+            click_button '更新'
+            expect(page).to have_content '片道の距離は1m~21,097m以内に設定してください'
+            expect(page).to have_content '入力情報に誤りがあります'
+          end
+        end
+
+        context '片道の距離に1を入力する' do
+          it '目的地の編集に成功し、スタートページに遷移する' do
+            distance = 1
+            fill_in '片道の距離', with: distance
+            click_button '更新'
+            expect(page).to have_content "#{distance}m"
+          end
+        end
+
+        context '片道の距離に21,097を入力する' do
+          it '目的地の編集に成功し、スタートページに遷移する' do
+            distance = 21_097
+            fill_in '片道の距離', with: distance
+            click_button '更新'
+            expect(page).to have_content "#{distance}m"
+          end
+        end
+
+        context '片道の距離に21,098を入力する' do
+          it '目的地の編集に失敗し、編集状態に戻る' do
+            distance = 21_098
+            fill_in '片道の距離', with: distance
+            click_button '更新'
+            expect(page).to have_content '片道の距離は1m~21,097m以内に設定してください'
+            expect(page).to have_content '入力情報に誤りがあります'
+          end
+        end
+      end
+    end
+
+    describe 'Form' do
+      let(:published_comment_destination) { create(:destination, :published_comment) }
+
+      before do
+        visit_start_page_from_saved(published_comment_destination)
+        sleep(0.1)
+        find('.fa.fa-chevron-down').click
+        click_link('編集')
+      end
+
+      context '編集フォームを表示させる' do
+        it 'フォームが表示され、初期値が入っている' do
+          expect(page).to have_field '名称', with: published_comment_destination.name
+          expect(page).to have_field 'コメント', with: published_comment_destination.comment
+          expect(page).to have_checked_field 'コメントを公開する'
+          expect(page).to have_field '片道の距離', with: published_comment_destination.distance
+        end
+      end
+
+      context '名称を入力し、作成に失敗する' do
+        it 'フォームから入力した名称が消えていない' do
+          name = 'a' * 51
+          fill_in '名称', with: name
+          click_button '更新'
+          expect(page).to have_field '名称', with: name
+        end
+      end
+
+      context 'コメントを入力し、作成に失敗する' do
+        it 'フォームから入力したコメントが消えていない' do
+          comment = 'a' * 256
+          fill_in 'コメント', with: comment
+          click_button '更新'
+          expect(page).to have_field 'コメント', with: comment
+        end
+      end
+
+      context '作成に失敗する' do
+        it '変更したチェックボックスがもとに戻っていない' do
+          fill_in '名称', with: 'a' * 51
+          check 'コメントを公開する'
+          click_button '更新'
+          expect(page).to have_checked_field 'コメントを公開する'
+        end
+      end
+
+      context '片道の距離を入力し、作成に失敗する' do
+        it 'フォームから入力した片道の距離が消えていない' do
+          distance = 21_098
+          fill_in '片道の距離', with: distance
+          click_button '更新'
+          expect(page).to have_field '片道の距離', with: distance
+        end
+      end
+    end
+
+    describe 'Cancel' do
+      before do
+        visit_start_page_from_saved(destination)
+        sleep(0.1)
+        find('.fa.fa-chevron-down').click
+        click_link('編集')
+      end
+
+      context '編集フォームを表示させた後、取り消しボタンを押す' do
+        it '目的地が適切に表示される' do
+          click_link '取消'
+          expect(page).to have_content destination.name
+        end
+      end
+
+      context '編集フォームを表示させ、内容を変えた後、取り消しボタンを押す' do
+        it '更新されていない目的地が適切に表示される' do
+          fill_in '名称', with: destination_form.name
+          fill_in 'コメント', with: destination_form.comment
+          check 'コメントを公開する'
+          fill_in '片道の距離', with: destination_form.distance
+          click_link '取消'
+          expect(page).to have_content destination.name
+          expect(page).to have_content destination.distance
+
+          expect(page).not_to have_content destination_form.name
+          expect(page).not_to have_content destination_form.comment
+          expect(page).not_to have_css '.fa.fa-commenting'
+          expect(page).not_to have_css '.fa.fa-eye'
+          expect(page).not_to have_css '.fa.fa-eye-slash'
+          expect(page).not_to have_content destination_form.distance
+        end
       end
     end
   end

--- a/spec/system/search/starts_spec.rb
+++ b/spec/system/search/starts_spec.rb
@@ -1,0 +1,109 @@
+require 'rails_helper'
+
+RSpec.describe 'Search::Starts' do
+  let(:departure) { create(:departure, is_saved: true) }
+  let(:destination) { create(:destination, is_saved: true) }
+  let(:nearby_result) { Settings.nearby_result.radius_1000.to_hash }
+  let(:destination_form) { build(:destination_form) }
+
+  describe 'Page' do
+    context '目的地を作成するページから、スタートするページにアクセスする' do
+      it '情報が正しく表示されている' do
+        nearby_mock(nearby_result)
+        visit_start_page_from_new(departure)
+        expect(page).to have_current_path new_history_path
+      end
+    end
+
+    context '保存済み目的地ページから、スタートするページにアクセスする' do
+      it '情報が正しく表示されている' do
+        visit_start_page_from_saved(destination)
+        expect(page).to have_current_path new_history_path(destination: destination.uuid)
+      end
+    end
+  end
+
+  describe 'Contents' do
+    context 'スタートするページにアクセスする' do
+      it '必ず表示されるコンテンツが正しく表示されている' do
+        visit_start_page_from_saved(destination)
+        expect(page).to have_content destination.name
+        expect(page).to have_content "#{destination.distance}m"
+        expect(page).to have_content destination.address
+        expect(page).to have_content destination.departure.name
+      end
+    end
+
+    context '目的地を保存し、スタートするページにアクセスする' do
+      before { visit_start_page_from_saved(destination) }
+
+      it 'コンテンツが正しく表示されている' do
+        expect(page).to have_current_path new_history_path(destination: destination.uuid)
+        expect(page).to have_content I18n.l(destination.created_at, format: :short)
+      end
+
+      it 'リンク関連が正しく表示されている' do
+        expect(page).to have_link 'スタート(片道)', href: histories_path(course: 'one_way')
+        expect(find('a', text: 'スタート(片道)')['data-turbo-method']).to eq 'post'
+        expect(page).to have_link 'スタート(往復)', href: histories_path(course: 'round_trip')
+        expect(find('a', text: 'スタート(往復)')['data-turbo-method']).to eq 'post'
+      end
+    end
+
+    context '目的地を保存せず、スタートするページにアクセスする' do
+      before do
+        nearby_mock(nearby_result)
+        visit_start_page_from_new(departure)
+      end
+
+      it 'コンテンツが正しく表示されている' do
+        expect(page).to have_current_path new_history_path
+        expect(page).to have_content '未保存'
+      end
+
+      it 'リンク関連が正しく表示されている' do
+        expect(page).to have_link 'スタート(片道)', href: histories_path(course: 'one_way')
+        expect(find('a', text: 'スタート(片道)')['data-turbo-method']).to eq 'post'
+        expect(page).to have_link 'スタート(往復)', href: histories_path(course: 'round_trip')
+        expect(find('a', text: 'スタート(往復)')['data-turbo-method']).to eq 'post'
+      end
+    end
+
+    context 'コメントをし、スタートするページにアクセスする' do
+      it 'コメントアイコンが表示されている' do
+        commented_destination = create(:destination, :commented)
+        visit_start_page_from_saved(commented_destination)
+        expect(page).to have_current_path new_history_path(destination: commented_destination.uuid)
+        expect(page).to have_css '.fa.fa-commenting'
+      end
+    end
+
+    context 'コメントをせず、スタートするページにアクセスする' do
+      it 'コメントアイコンが表示されていない' do
+        visit_start_page_from_saved(destination)
+        expect(page).to have_current_path new_history_path(destination: destination.uuid)
+        expect(page).not_to have_css '.fa.fa-commenting'
+      end
+    end
+
+    context 'コメントを公開し、スタートするページにアクセスする' do
+      it '公開アイコンが表示されている' do
+        published_comment_destination = create(:destination, :published_comment)
+        visit_start_page_from_saved(published_comment_destination)
+        expect(page).to have_current_path new_history_path(destination: published_comment_destination.uuid)
+        expect(page).to have_css '.fa.fa-eye'
+        expect(page).not_to have_css '.fa.fa-eye-slash'
+      end
+    end
+
+    context 'コメントを非公開にし、スタートするページにアクセスする' do
+      it '非公開アイコンが表示されている' do
+        not_published_comment_destination = create(:destination, :not_published_comment)
+        visit_start_page_from_saved(not_published_comment_destination)
+        expect(page).to have_current_path new_history_path(destination: not_published_comment_destination.uuid)
+        expect(page).not_to have_css '.fa.fa-eye'
+        expect(page).to have_css '.fa.fa-eye-slash'
+      end
+    end
+  end
+end

--- a/spec/system/search/starts_spec.rb
+++ b/spec/system/search/starts_spec.rb
@@ -22,6 +22,19 @@ RSpec.describe 'Search::Starts' do
         expect(page).to have_current_path new_history_path(destination: destination.uuid)
       end
     end
+
+    context '保存済み目的地ページから、スタートするページにアクセスし、編集状態にする' do
+      it '情報が正しく表示されている' do
+        visit_start_page_from_saved(destination)
+        sleep(0.1)
+        find('.fa.fa-chevron-down').click
+        click_link('編集')
+        expect(page).to have_field '名称'
+        expect(page).to have_field 'コメント'
+        expect(page).to have_unchecked_field 'コメントを公開する'
+        expect(page).to have_field '片道の距離'
+      end
+    end
   end
 
   describe 'Contents' do

--- a/spec/system/signup_spec.rb
+++ b/spec/system/signup_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe 'Signup' do
   let(:user) { create(:user) }
 
-  describe 'ユーザー新規登録' do
-    before { visit signup_path }
+  before { visit signup_path }
 
+  describe 'New' do
     describe 'Validations' do
       context '正常な値を入力する' do
         it 'ユーザーの新規作成が成功し、プロフィールページに遷移する' do
@@ -164,6 +164,20 @@ RSpec.describe 'Signup' do
           click_button '登録'
           expect(page).to have_field 'パスワード（確認用）', with: ''
         end
+      end
+    end
+  end
+
+  describe 'Database' do
+    context 'サインアップする' do
+      it 'ユーザーが作成される' do
+        fill_in '名前', with: 'user-name'
+        fill_in 'メールアドレス', with: 'user-email@example.com'
+        fill_in 'パスワード', with: 'user-password'
+        fill_in 'パスワード（確認用）', with: 'user-password'
+        click_button '登録'
+        sleep(0.1)
+        expect(User.count).to eq 1
       end
     end
   end


### PR DESCRIPTION
- 目的地作成、スタート、ゴール、履歴詳細のSystemSpec
└ #67
- ゴールページではcheck_not_finishedをskip
- destinations_controllerにて、@routeの取得に失敗していたので修正
- DestinationのModelSpecにて、コメント、公開、保存の相互作用を検証
└ #72
- ゲスト機能で現在地を取得できていなかったため、修正 
- ゲストの検索機能がPickCandidatesの導入などに対応できていなかったので修正
- JavaScriptでの住所整形ロジックを変更
└ #77